### PR TITLE
suggestions for you to consider or lose at your pleasure

### DIFF
--- a/cross_compiler.py
+++ b/cross_compiler.py
@@ -2217,7 +2217,7 @@ PRODUCTS = {
 			[ 'https://raw.githubusercontent.com/DeadSix27/python_cross_compile_script/master/patches/wget/wget.timegm.patch', '-p1' ],
 		],
 		'depends_on': (
-			'zlib', 'libressl', 'libpsl',
+			'zlib', 'libressl_2_8_2', 'libpsl',
 		),
 		'_info' : { 'version' : 'git (master)', 'fancy_name' : 'wget' },
 	},
@@ -2607,10 +2607,10 @@ PRODUCTS = {
 	# 		'{cross_prefix_bare}strip -v {product_prefix}/aria2_git.installed/bin/aria2c.exe',
 	# 	],
 	# 	'depends_on': [
-	# 		'zlib', 'libressl',
+	# 		'zlib', 'libressl_2_8_2',
 	# 	],
 	# 	# 'depends_on': [
-	# 		# 'zlib', 'libxml2', 'expat', 'gmp', 'libsqlite3', 'libssh2', 'cppunit', 'libressl', #'gnutls', # 'c-ares', 'libsqlite3', 'openssl_1_1'
+	# 		# 'zlib', 'libxml2', 'expat', 'gmp', 'libsqlite3', 'libssh2', 'cppunit', 'libressl_2_8_2', #'gnutls', # 'c-ares', 'libsqlite3', 'openssl_1_1'
 	# 	# ],
 	# 	'_info' : { 'version' : 'git (master)', 'fancy_name' : 'aria2' },
 	# },
@@ -3097,7 +3097,7 @@ DEPENDS = {
 			'--with-crypto=openssl'
 		,
 		'depends_on': (
-			'zlib', 'libressl'
+			'zlib', 'libressl_2_8_2'
 		),
 		'env_exports' : {
 			'LIBS' : '-lcrypt32' # Otherwise: libcrypto.a(e_capi.o):e_capi.c:(.text+0x476d): undefined reference to `__imp_CertFreeCertificateContext'
@@ -3253,6 +3253,28 @@ DEPENDS = {
 			( 'https://raw.githubusercontent.com/shinchiro/mpv-winbuild-cmake/master/packages/libressl-0001-ignore-compiling-test-and-man-module.patch', '-p1' ),
 		],
 		'_info' : { 'version' : 'git (master)', 'fancy_name' : 'libressl' },
+	},
+	'libressl_2_8_2' : { # 2018.11.12 since git libressl is broken :( :( :( ... build per Alexpux
+		'repo_type' : 'archive',
+		'folder_name' : 'libressl_2.8.2',
+		'download_locations' : [
+			#UPDATECHECKS: https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/
+			{ "url" : "https://fossies.org/linux/misc/libressl-2.8.2.tar.gz", "hashes" : [ { "type" : "sha256", "sum" : "b8cb31e59f1294557bfc80f2a662969bc064e83006ceef0574e2553a1c254fd5" }, ], },
+			{ "url" : "https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-2.8.2.tar.gz", "hashes" : [ { "type" : "sha256", "sum" : "b8cb31e59f1294557bfc80f2a662969bc064e83006ceef0574e2553a1c254fd5" }, ], },
+		],
+		'configure_options': '--host={target_host} --prefix={target_prefix} --disable-shared --enable-static ',
+		'patches' : [
+			( 'https://raw.githubusercontent.com/hydra3333/python_cross_compile_script/master/patches/libressl-from-Alexpux/libressl-0001-ignore-compiling-test-and-man-module.patch', '-Np1' ),
+		],
+		'run_post_patch' : (
+			'cp -fv libtls.pc.in liblibretls.pc.in', 
+			'cp -fv libcrypto.pc.in liblibrecrypto.pc.in', 
+			'cp -fv libssl.pc.in liblibressl.pc.in', 
+			'cp -fv openssl.pc.in libressl.pc.in', 
+			'cp -fv apps/openssl/openssl.c apps/openssl/libressl.c', 
+			'autoreconf -fiv',
+		),
+		'_info' : { 'version' : '2.8.2', 'fancy_name' : 'libressl' },
 	},
 	'libpsl' : {
 		'repo_type' : 'git',
@@ -5018,7 +5040,7 @@ DEPENDS = {
 	#		'--with-crypto=openssl'
 	#	,
 	#	'depends_on': (
-	#		'zlib', 'libressl'
+	#		'zlib', 'libressl_2_8_2'
 	#	),
 	#	'env_exports' : {
 	#		'LIBS' : '-lcrypt32' # Otherwise: libcrypto.a(e_capi.o):e_capi.c:(.text+0x476d): undefined reference to `__imp_CertFreeCertificateContext'

--- a/cross_compiler.py
+++ b/cross_compiler.py
@@ -42,7 +42,7 @@ _LOG_DATEFORMAT    = '%H:%M:%S' # default: %H:%M:%S
 _LOGFORMAT         = '[%(asctime)s][%(levelname)s] %(message)s' # default: [%(asctime)s][%(levelname)s] %(message)s
 _WORKDIR           = 'workdir' # default: workdir
 _MINGW_DIR         = 'toolchain' # default: toolchain
-_MINGW_COMMIT      = 'c69c7a706d767c5ca3c7d1c70887fcd8e1f940b3' #'08189cc9655a6fa6023e80e31d8226536ee23ab2' # See https://sourceforge.net/p/mingw-w64/mingw-w64/ci/master/log/?path= # I prefer to stay on a known good commit for mingw.
+_MINGW_COMMIT      = '8a9a6eebe110e7170dcd8e6e4b37d5ba6cb8ae87' #'08189cc9655a6fa6023e80e31d8226536ee23ab2' # See https://sourceforge.net/p/mingw-w64/mingw-w64/ci/master/log/?path= # I prefer to stay on a known good commit for mingw.
 _MINGW_DEBUG_BUILD = False # Setting this to true, will build the toolchain with -ggdb -O0, instead of -ggdb -O3
 _BITNESS           = ( 64, ) # Only 64 bit is supported (32 bit is not even implemented, no one should need this today...)
 _ORIG_CFLAGS       = '-ggdb -O3' # Set options like -march=skylake or -ggdb for debugging here. # Default: -ggdb -O3
@@ -3620,7 +3620,9 @@ DEPENDS = {
 	'nv-codec-headers' : { # https://git.videolan.org/?p=ffmpeg/nv-codec-headers.git;a=shortlog
 		'repo_type' : 'git',
 		'url' : 'https://git.videolan.org/git/ffmpeg/nv-codec-headers.git',
-		"needs_configure": False,
+		# commit after 450c616c7242afc577fb6ecd01732495fc263520 require API 8.2 yet nvidia drivers to 416.94 (eg for a 1050Ti) only ship with API 8.1
+		# ffmpeg throws a runtime Error:  "nvenc API version. Required: 8.2 Found: 8.1"
+		'branch' : '450c616c7242afc577fb6ecd01732495fc263520', 		"needs_configure": False,
 		'make_options': 'PREFIX={target_prefix}',
 		'install_options' : 'PREFIX={target_prefix}',
 		'_info' : { 'version' : 'git (master)', 'fancy_name' : 'nVidia (headers)' },

--- a/cross_compiler.py
+++ b/cross_compiler.py
@@ -3251,6 +3251,7 @@ DEPENDS = {
 		'configure_options': '--host={target_host} --prefix={target_prefix} --disable-shared --enable-static ',
 		'patches' : [
 			( 'https://raw.githubusercontent.com/shinchiro/mpv-winbuild-cmake/master/packages/libressl-0001-ignore-compiling-test-and-man-module.patch', '-p1' ),
+		],
 		'_info' : { 'version' : 'git (master)', 'fancy_name' : 'libressl' },
 	},
 	'libpsl' : {
@@ -4457,7 +4458,6 @@ DEPENDS = {
 			('https://raw.githubusercontent.com/Alexpux/MINGW-packages/master/mingw-w64-lame/0006-dont-use-outdated-symbol-list.patch','-Np1'),
 			('https://raw.githubusercontent.com/Alexpux/MINGW-packages/master/mingw-w64-lame/0007-revert-posix-code.patch','-Np1'),
 			('https://raw.githubusercontent.com/Alexpux/MINGW-packages/master/mingw-w64-lame/0008-skip-termcap.patch','-Np1'),
-		),
 		),
 		'run_post_patch' : (
 			'autoreconf -fiv',

--- a/cross_compiler.py
+++ b/cross_compiler.py
@@ -2151,6 +2151,29 @@ PRODUCTS = {
 		,
 		'_info' : { 'version' : 'git (master)', 'fancy_name' : 'aom-av1' },
 	},
+	'vpx' : {
+		'repo_type' : 'git',
+		'url' : 'https://chromium.googlesource.com/webm/libvpx',
+		'rename_folder' : 'vpx_git',
+		'configure_options':
+			'--target={bit_name2}-{bit_name_win}-gcc '
+			'--prefix={product_prefix}/vpx_git.installed '
+			'--disable-shared --enable-static --enable-webm-io --enable-vp9 '
+			'--enable-vp8 --enable-runtime-cpu-detect '
+			'--enable-vp9-highbitdepth --enable-vp9-postproc --enable-coefficient-range-checking '
+			'--enable-error-concealment --enable-better-hw-compatibility '
+			'--enable-multi-res-encoding --enable-vp9-temporal-denoising '
+			'--enable-tools --disable-docs --enable-examples --disable-install-docs --disable-unit-tests --disable-decode-perf-tests --disable-encode-perf-tests --disable-avx512 --as=nasm' #--as=yasm'
+		,
+		'env_exports' : {
+			'CROSS' : '{cross_prefix_bare}',
+		},
+		'custom_cflag' : '-fno-asynchronous-unwind-tables',
+		'patches': (
+			( 'https://raw.githubusercontent.com/hydra3333/h3333_python_cross_compile_script/master/patches/vpx_160_semaphore.patch', '-p1' ),
+		),
+		'_info' : { 'version' : 'git (master)', 'fancy_name' : 'vpx' },
+	},
 	'scxvid' : {
 		'repo_type' : 'git',
 		'url' : 'https://github.com/DeadSix27/SCXvid-standalone',

--- a/cross_compiler.py
+++ b/cross_compiler.py
@@ -1481,7 +1481,7 @@ class CrossCompileScript:
 			if data['is_cmake'] == True:
 				self.cmake_source(name,data)
 
-  		if 'is_meson_ninja' in data:
+		if 'is_meson_ninja' in data:
 			if data['is_meson_ninja'] == True:
 				self.meson_source(name,data) # set the meson optyions and run meson
 				self.ninja_source(name,data) # set the ninja options and run ninja

--- a/cross_compiler.py
+++ b/cross_compiler.py
@@ -2225,9 +2225,9 @@ PRODUCTS = {
 		'repo_type' : 'git',
 		'url' : 'git://git.ffmpeg.org/ffmpeg.git',
 		'rename_folder' : 'ffmpeg_static_git',
-		'patches': (
-			'',
-		),
+		#'patches': (
+		#	'',
+		#),
 		'configure_options': '!VAR(ffmpeg_base_config)VAR! --enable-libbluray --prefix={product_prefix}/ffmpeg_static_git.installed --disable-shared --enable-static --extra-cflags="-DLIBXML_STATIC" --extra-cflags="-DGLIB_STATIC_COMPILATION" ',
 		'depends_on': [ 'ffmpeg_depends' ],
 		'_info' : { 'version' : 'git (master)', 'fancy_name' : 'ffmpeg (static)' },
@@ -2236,9 +2236,9 @@ PRODUCTS = {
 		'repo_type' : 'git',
 		'url' : 'git://git.ffmpeg.org/ffmpeg.git',
 		'rename_folder' : 'ffmpeg_static_opencl_git',
-		'patches': (
-			'',
-		),
+		#'patches': (
+		#	'',
+		#),
 		'configure_options': '!VAR(ffmpeg_base_config)VAR! --enable-libbluray --prefix={product_prefix}/ffmpeg_static_opencl_git.installed --disable-shared --enable-static --enable-opencl --extra-cflags="-DLIBXML_STATIC" --extra-cflags="-DGLIB_STATIC_COMPILATION" ',
 		'depends_on': [ 'ffmpeg_depends', 'opencl_icd' ],
 		'_info' : { 'version' : 'git (master)', 'fancy_name' : 'ffmpeg (static (OpenCL))' },
@@ -2247,9 +2247,9 @@ PRODUCTS = {
 		'repo_type' : 'git',
 		'url' : 'git://git.ffmpeg.org/ffmpeg.git',
 		'rename_folder' : 'ffmpeg_static_non_free',
-		'patches': (
-			'',
-		),
+		#'patches': (
+		#	'',
+		#),
 		'configure_options': '!VAR(ffmpeg_base_config)VAR! --enable-libbluray --prefix={product_prefix}/ffmpeg_static_non_free.installed --disable-shared --enable-static --enable-nonfree --enable-libfdk-aac --enable-decklink --extra-cflags="-DLIBXML_STATIC" --extra-cflags="-DGLIB_STATIC_COMPILATION" ',
 		'depends_on': [ 'ffmpeg_depends', 'decklink_headers', 'fdk_aac' ],
 		'_info' : { 'version' : 'git (master)', 'fancy_name' : 'ffmpeg NonFree (static)' },
@@ -2258,9 +2258,9 @@ PRODUCTS = {
 		'repo_type' : 'git',
 		'url' : 'git://git.ffmpeg.org/ffmpeg.git',
 		'rename_folder' : 'ffmpeg_static_non_free_opencl',
-		'patches': (
-			'',
-		),
+		#'patches': (
+		#	'',
+		#),
 		'configure_options': '!VAR(ffmpeg_base_config)VAR! --enable-libbluray --prefix={product_prefix}/ffmpeg_static_non_free_opencl.installed --disable-shared --enable-static --enable-opencl --enable-nonfree --enable-libfdk-aac --enable-decklink --extra-cflags="-DLIBXML_STATIC" --extra-cflags="-DGLIB_STATIC_COMPILATION" ',
 		'depends_on': [ 'ffmpeg_depends', 'decklink_headers', 'fdk_aac', 'opencl_icd' ],
 		'_info' : { 'version' : 'git (master)', 'fancy_name' : 'ffmpeg NonFree (static (OpenCL))' },
@@ -2269,9 +2269,9 @@ PRODUCTS = {
 		'repo_type' : 'git',
 		'url' : 'git://git.ffmpeg.org/ffmpeg.git',
 		'rename_folder' : 'ffmpeg_shared_git',
-		'patches': (
-			'',
-		),
+		#'patches': (
+		#	'',
+		#),
 		'configure_options': '!VAR(ffmpeg_base_config)VAR! --prefix={product_prefix}/ffmpeg_shared_git.installed --enable-shared --disable-static --disable-libbluray --disable-libgme',
 		'depends_on': [ 'ffmpeg_depends' ],
 		'_info' : { 'version' : 'git (master)', 'fancy_name' : 'ffmpeg (shared)' },
@@ -3109,9 +3109,9 @@ DEPENDS = {
 		'url' : 'https://github.com/curl/curl',
 		'rename_folder' : 'curl_git',
 		'configure_options': '--enable-static --disable-shared --target={bit_name2}-{bit_name_win}-gcc --host={target_host} --build=x86_64-linux-gnu --with-libssh2 --with-gnutls --prefix={target_prefix} --exec-prefix={target_prefix}',
-		'patches' : [
-			'',
-		],
+		#'patches' : [
+		#	'',
+		#],
 		'depends_on': (
 			'zlib','libssh2',
 		),
@@ -3607,9 +3607,9 @@ DEPENDS = {
 		'url' : 'git://git.ffmpeg.org/ffmpeg.git',
 		'rename_folder' : 'libffmpeg_git',
 		'configure_options': '!VAR(ffmpeg_base_config)VAR! --prefix={target_prefix} --disable-shared --enable-static --disable-doc --disable-programs --enable-amf --extra-cflags="-DLIBXML_STATIC" --extra-cflags="-DGLIB_STATIC_COMPILATION" ',
-		'patches' : (
-			'', 
-		),
+		#'patches' : (
+		#	'', 
+		#),
 		'depends_on': [ 'ffmpeg_depends' ],
 		'_info' : { 'version' : 'git (master)', 'fancy_name' : 'FFmpeg (library)' },
 	},

--- a/patches/glib2/disable_libmount-make-UTF-yes.patch
+++ b/patches/glib2/disable_libmount-make-UTF-yes.patch
@@ -1,0 +1,68 @@
+--- configure.ac.orig	2018-08-10 19:15:29.674842931 -0700
++++ configure.ac	2018-08-10 19:29:56.173833000 -0700
+@@ -1753,11 +1753,12 @@
+ dnl The fallback code doesn't really implement the same behaviors - e.g.
+ dnl so on linux we want to require libmount unless specifically disabled
+ dnl
+-enable_libmount_default=${glib_os_linux:-no}
++enable_libmount_default=no
++enable_libmount=no
+ AC_ARG_ENABLE(libmount,
+               [AS_HELP_STRING([--enable-libmount],
+                               [build with libmount support [default for Linux]])],,
+-              [enable_libmount=$enable_libmount_default])
++              [enable_libmount=no])
+ AS_IF([ test "x$enable_libmount" = "xyes"],[
+ PKG_CHECK_MODULES([LIBMOUNT], [mount >= 2.23], [have_libmount=yes], [have_libmount=no])
+ if test $have_libmount = no ; then
+@@ -2366,27 +2367,29 @@
+ AS_IF([ test "x$with_pcre" = xsystem], [
+   PKG_CHECK_MODULES(PCRE,
+                     libpcre >= $PCRE_REQUIRED_VERSION)
+-  AC_CACHE_CHECK([for Unicode support in PCRE],glib_cv_pcre_has_unicode,[
+-                  glib_save_CFLAGS="$CFLAGS"
+-                  glib_save_LIBS="$LIBS"
+-                  CFLAGS="$CFLAGS $PCRE_CFLAGS" LIBS="$PCRE_LIBS"
+-                  AC_TRY_RUN([#include <pcre.h>
+-                              int main () {
+-                                int support;
+-                                pcre_config (PCRE_CONFIG_UTF8, &support);
+-                                if (!support)
+-                                  return 1;
+-                                pcre_config (PCRE_CONFIG_UNICODE_PROPERTIES, &support);
+-                                if (!support)
+-                                  return 1;
+-                                return 0;
+-                              }],
+-                  glib_cv_pcre_has_unicode=yes,
+-                  glib_cv_pcre_has_unicode=no,
+-                  glib_cv_pcre_has_unicode=yes)
+-                  CFLAGS="$glib_save_CFLAGS"
+-                  LIBS="$glib_save_LIBS"
+-      ])
++#  AC_CACHE_CHECK([for Unicode support in PCRE],glib_cv_pcre_has_unicode,[
++#                  glib_save_CFLAGS="$CFLAGS"
++#                  glib_save_LIBS="$LIBS"
++#                  CFLAGS="$CFLAGS $PCRE_CFLAGS" LIBS="$PCRE_LIBS"
++#                  AC_TRY_RUN([#include <pcre.h>
++#                              int main () {
++#                                int support;
++#                                pcre_config (PCRE_CONFIG_UTF8, &support);
++#                                if (!support)
++#                                  return 1;
++#                                pcre_config (PCRE_CONFIG_UNICODE_PROPERTIES, &support);
++#                                if (!support)
++#                                  return 1;
++#                                return 0;
++#                              }],
++#                  glib_cv_pcre_has_unicode=yes,
++#                  glib_cv_pcre_has_unicode=no,
++#                  glib_cv_pcre_has_unicode=yes)
++#                  CFLAGS="$glib_save_CFLAGS"
++#                  LIBS="$glib_save_LIBS"
++#      ])
++                  glib_cv_pcre_has_unicode=yes
++                  #glib_cv_pcre_has_unicode=no
+   if test "$glib_cv_pcre_has_unicode" = "no"; then
+     AC_MSG_ERROR([*** The system-supplied PCRE does not support Unicode properties or UTF-8.])
+   fi

--- a/patches/libressl-from-Alexpux/0001-libressl_relocation-msys.patch
+++ b/patches/libressl-from-Alexpux/0001-libressl_relocation-msys.patch
@@ -1,0 +1,1922 @@
+ Makefile.am                      |    4 +-
+ apps/ocspcheck/Makefile.am       |    6 +-
+ apps/openssl/Makefile.am         |  120 ++--
+ configure.ac                     |    9 +-
+ crypto/Makefile.am               | 1134 +++++++++++++++++++-------------------
+ crypto/Makefile.am.elf-x86_64    |   32 +-
+ crypto/Makefile.am.macosx-x86_64 |   32 +-
+ libcrypto.pc.in                  |    6 +-
+ libssl.pc.in                     |    8 +-
+ libtls.pc.in                     |    6 +-
+ openssl.pc.in                    |    4 +-
+ ssl/Makefile.am                  |   82 +--
+ tests/Makefile.am                |    8 +-
+ tls/Makefile.am                  |   36 +-
+ 14 files changed, 743 insertions(+), 744 deletions(-)
+
+diff --git a/Makefile.am b/Makefile.am
+index b4b9dfc..5bcd0e1 100644
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -1,8 +1,8 @@
+-SUBDIRS = crypto ssl tls include apps tests man
++SUBDIRS = crypto ssl tls include apps tests
+ ACLOCAL_AMFLAGS = -I m4
+ 
+ pkgconfigdir = $(libdir)/pkgconfig
+-pkgconfig_DATA = libcrypto.pc libssl.pc libtls.pc openssl.pc
++pkgconfig_DATA = liblibrecrypto.pc liblibressl.pc liblibretls.pc libressl.pc
+ 
+ EXTRA_DIST = README.md README.windows VERSION config scripts
+ EXTRA_DIST += CMakeLists.txt cmake_export_symbol.cmake cmake_uninstall.cmake.in
+diff --git a/apps/ocspcheck/Makefile.am b/apps/ocspcheck/Makefile.am
+index f7eb131..ae4f558 100644
+--- a/apps/ocspcheck/Makefile.am
++++ b/apps/ocspcheck/Makefile.am
+@@ -5,9 +5,9 @@ bin_PROGRAMS = ocspcheck
+ EXTRA_DIST = ocspcheck.8
+ EXTRA_DIST += CMakeLists.txt
+ 
+-ocspcheck_LDADD = $(abs_top_builddir)/crypto/libcrypto.la
+-ocspcheck_LDADD += $(abs_top_builddir)/ssl/libssl.la
+-ocspcheck_LDADD += $(abs_top_builddir)/tls/libtls.la
++ocspcheck_LDADD = $(abs_top_builddir)/crypto/liblibrecrypto.la
++ocspcheck_LDADD += $(abs_top_builddir)/ssl/liblibressl.la
++ocspcheck_LDADD += $(abs_top_builddir)/tls/liblibretls.la
+ ocspcheck_LDADD += $(PLATFORM_LDADD) $(PROG_LDADD)
+ 
+ ocspcheck_SOURCES = http.c
+diff --git a/apps/openssl/Makefile.am b/apps/openssl/Makefile.am
+index 9b9eb10..8b28ddb 100644
+--- a/apps/openssl/Makefile.am
++++ b/apps/openssl/Makefile.am
+@@ -1,87 +1,87 @@
+ include $(top_srcdir)/Makefile.am.common
+ 
+-bin_PROGRAMS = openssl
++bin_PROGRAMS = libressl
+ 
+ dist_man_MANS = openssl.1
+ 
+-openssl_LDADD = $(abs_top_builddir)/ssl/libssl.la
+-openssl_LDADD += $(abs_top_builddir)/crypto/libcrypto.la
+-openssl_LDADD += $(PLATFORM_LDADD) $(PROG_LDADD)
++libressl_LDADD = $(abs_top_builddir)/ssl/liblibressl.la
++libressl_LDADD += $(abs_top_builddir)/crypto/liblibrecrypto.la
++libressl_LDADD += $(PLATFORM_LDADD) $(PROG_LDADD)
+ 
+-openssl_SOURCES = apps.c
+-openssl_SOURCES += asn1pars.c
+-openssl_SOURCES += ca.c
+-openssl_SOURCES += ciphers.c
+-openssl_SOURCES += crl.c
+-openssl_SOURCES += crl2p7.c
+-openssl_SOURCES += dgst.c
+-openssl_SOURCES += dh.c
+-openssl_SOURCES += dhparam.c
+-openssl_SOURCES += dsa.c
+-openssl_SOURCES += dsaparam.c
+-openssl_SOURCES += ec.c
+-openssl_SOURCES += ecparam.c
+-openssl_SOURCES += enc.c
+-openssl_SOURCES += errstr.c
+-openssl_SOURCES += gendh.c
+-openssl_SOURCES += gendsa.c
+-openssl_SOURCES += genpkey.c
+-openssl_SOURCES += genrsa.c
+-openssl_SOURCES += nseq.c
+-openssl_SOURCES += ocsp.c
+-openssl_SOURCES += openssl.c
+-openssl_SOURCES += passwd.c
+-openssl_SOURCES += pkcs12.c
+-openssl_SOURCES += pkcs7.c
+-openssl_SOURCES += pkcs8.c
+-openssl_SOURCES += pkey.c
+-openssl_SOURCES += pkeyparam.c
+-openssl_SOURCES += pkeyutl.c
+-openssl_SOURCES += prime.c
+-openssl_SOURCES += rand.c
+-openssl_SOURCES += req.c
+-openssl_SOURCES += rsa.c
+-openssl_SOURCES += rsautl.c
+-openssl_SOURCES += s_cb.c
+-openssl_SOURCES += s_client.c
+-openssl_SOURCES += s_server.c
+-openssl_SOURCES += s_socket.c
+-openssl_SOURCES += s_time.c
+-openssl_SOURCES += sess_id.c
+-openssl_SOURCES += smime.c
+-openssl_SOURCES += speed.c
+-openssl_SOURCES += spkac.c
+-openssl_SOURCES += ts.c
+-openssl_SOURCES += verify.c
+-openssl_SOURCES += version.c
+-openssl_SOURCES += x509.c
++libressl_SOURCES = apps.c
++libressl_SOURCES += asn1pars.c
++libressl_SOURCES += ca.c
++libressl_SOURCES += ciphers.c
++libressl_SOURCES += crl.c
++libressl_SOURCES += crl2p7.c
++libressl_SOURCES += dgst.c
++libressl_SOURCES += dh.c
++libressl_SOURCES += dhparam.c
++libressl_SOURCES += dsa.c
++libressl_SOURCES += dsaparam.c
++libressl_SOURCES += ec.c
++libressl_SOURCES += ecparam.c
++libressl_SOURCES += enc.c
++libressl_SOURCES += errstr.c
++libressl_SOURCES += gendh.c
++libressl_SOURCES += gendsa.c
++libressl_SOURCES += genpkey.c
++libressl_SOURCES += genrsa.c
++libressl_SOURCES += nseq.c
++libressl_SOURCES += ocsp.c
++libressl_SOURCES += libressl.c
++libressl_SOURCES += passwd.c
++libressl_SOURCES += pkcs12.c
++libressl_SOURCES += pkcs7.c
++libressl_SOURCES += pkcs8.c
++libressl_SOURCES += pkey.c
++libressl_SOURCES += pkeyparam.c
++libressl_SOURCES += pkeyutl.c
++libressl_SOURCES += prime.c
++libressl_SOURCES += rand.c
++libressl_SOURCES += req.c
++libressl_SOURCES += rsa.c
++libressl_SOURCES += rsautl.c
++libressl_SOURCES += s_cb.c
++libressl_SOURCES += s_client.c
++libressl_SOURCES += s_server.c
++libressl_SOURCES += s_socket.c
++libressl_SOURCES += s_time.c
++libressl_SOURCES += sess_id.c
++libressl_SOURCES += smime.c
++libressl_SOURCES += speed.c
++libressl_SOURCES += spkac.c
++libressl_SOURCES += ts.c
++libressl_SOURCES += verify.c
++libressl_SOURCES += version.c
++libressl_SOURCES += x509.c
+ 
+ if BUILD_CERTHASH
+-openssl_SOURCES += certhash.c
++libressl_SOURCES += certhash.c
+ else
+-openssl_SOURCES += certhash_win.c
++libressl_SOURCES += certhash_win.c
+ endif
+ 
+ if HOST_WIN
+-openssl_SOURCES += apps_win.c
++libressl_SOURCES += apps_win.c
+ else
+-openssl_SOURCES += apps_posix.c
++libressl_SOURCES += apps_posix.c
+ endif
+ 
+ if !HAVE_POLL
+ if HOST_WIN
+-openssl_SOURCES += compat/poll_win.c
++libressl_SOURCES += compat/poll_win.c
+ endif
+ endif
+ 
+ if !HAVE_CLOCK_GETTIME
+ if HOST_DARWIN
+-openssl_SOURCES += compat/clock_gettime_osx.c
++libressl_SOURCES += compat/clock_gettime_osx.c
+ endif
+ endif
+ 
+ if !HAVE_STRTONUM
+-openssl_SOURCES += compat/strtonum.c
++libressl_SOURCES += compat/strtonum.c
+ endif
+ 
+ noinst_HEADERS = apps.h
+@@ -86,7 +86,7 @@ noinst_HEADERS += testrsa.h
+ noinst_HEADERS += timeouts.h
+ 
+ EXTRA_DIST = cert.pem
+-EXTRA_DIST += openssl.cnf
++EXTRA_DIST += libressl.cnf
+ EXTRA_DIST += x509v3.cnf
+ EXTRA_DIST += CMakeLists.txt
+ 
+@@ -97,7 +97,7 @@ install-exec-hook:
+ 		OPENSSLDIR="$(DESTDIR)$(sysconfdir)/ssl"; \
+ 	fi; \
+ 	mkdir -p "$$OPENSSLDIR/certs"; \
+-	for i in cert.pem openssl.cnf x509v3.cnf; do \
++	for i in cert.pem libressl.cnf x509v3.cnf; do \
+ 		if [ ! -f "$$OPENSSLDIR/$i" ]; then \
+ 			$(INSTALL) -m 644 "$(srcdir)/$$i" "$$OPENSSLDIR/$$i"; \
+ 		else \
+@@ -111,7 +111,7 @@ uninstall-local:
+ 	else \
+ 		OPENSSLDIR="$(DESTDIR)$(sysconfdir)/ssl"; \
+ 	fi; \
+-	for i in cert.pem openssl.cnf x509v3.cnf; do \
++	for i in cert.pem libressl.cnf x509v3.cnf; do \
+ 		if cmp -s "$$OPENSSLDIR/$$i" "$(srcdir)/$$i"; then \
+ 			rm -f "$$OPENSSLDIR/$$i"; \
+ 		fi \
+diff --git a/configure.ac b/configure.ac
+index 6f98b3e..cf0d481 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -125,11 +125,10 @@ AC_CONFIG_FILES([
+ 	apps/ocspcheck/Makefile
+ 	apps/openssl/Makefile
+ 	apps/nc/Makefile
+-	man/Makefile
+-	libcrypto.pc
+-	libssl.pc
+-	libtls.pc
+-	openssl.pc
++	liblibrecrypto.pc
++	liblibressl.pc
++	liblibretls.pc
++	libressl.pc
+ ])
+ 
+ AM_CONDITIONAL([SMALL_TIME_T], [test "$ac_cv_sizeof_time_t" = "4"])
+diff --git a/crypto/Makefile.am b/crypto/Makefile.am
+index 046a623..cf5ee9e 100644
+--- a/crypto/Makefile.am
++++ b/crypto/Makefile.am
+@@ -6,7 +6,7 @@
+ AM_CPPFLAGS += -I$(top_srcdir)/crypto/modes
+ AM_CPPFLAGS += -I$(top_srcdir)/crypto
+ 
+-lib_LTLIBRARIES = libcrypto.la
++lib_LTLIBRARIES = liblibrecrypto.la
+ 
+ EXTRA_DIST = VERSION
+ EXTRA_DIST += CMakeLists.txt
+@@ -89,26 +89,26 @@
+ 	-mv crypto_portable.sym.tmp crypto_portable.sym
+ endif
+ 
+-libcrypto_la_LDFLAGS = -version-info @LIBCRYPTO_VERSION@ -no-undefined -export-symbols crypto_portable.sym
+-libcrypto_la_LIBADD = libcompat.la
++liblibrecrypto_la_LDFLAGS = -version-info @LIBCRYPTO_VERSION@ -no-undefined -export-symbols crypto_portable.sym
++liblibrecrypto_la_LIBADD = libcompat.la
+ if !HAVE_EXPLICIT_BZERO
+-libcrypto_la_LIBADD += libcompatnoopt.la
++liblibrecrypto_la_LIBADD += libcompatnoopt.la
+ endif
+-libcrypto_la_CPPFLAGS = $(AM_CPPFLAGS)
+-libcrypto_la_CPPFLAGS += -DLIBRESSL_INTERNAL
+-libcrypto_la_CPPFLAGS += -DOPENSSL_NO_HW_PADLOCK
++liblibrecrypto_la_CPPFLAGS = $(AM_CPPFLAGS)
++liblibrecrypto_la_CPPFLAGS += -DLIBRESSL_INTERNAL
++liblibrecrypto_la_CPPFLAGS += -DOPENSSL_NO_HW_PADLOCK
+ if OPENSSL_NO_ASM
+-libcrypto_la_CPPFLAGS += -DOPENSSL_NO_ASM
++liblibrecrypto_la_CPPFLAGS += -DOPENSSL_NO_ASM
+ else
+ if HOST_WIN
+-libcrypto_la_CPPFLAGS += -DOPENSSL_NO_ASM
++liblibrecrypto_la_CPPFLAGS += -DOPENSSL_NO_ASM
+ endif
+ endif
+ 
+ if OPENSSLDIR_DEFINED
+-libcrypto_la_CPPFLAGS += -DOPENSSLDIR=\"@OPENSSLDIR@\"
++liblibrecrypto_la_CPPFLAGS += -DOPENSSLDIR=\"@OPENSSLDIR@\"
+ else
+-libcrypto_la_CPPFLAGS += -DOPENSSLDIR=\"$(sysconfdir)/ssl\"
++liblibrecrypto_la_CPPFLAGS += -DOPENSSLDIR=\"$(sysconfdir)/ssl\"
+ endif
+ 
+ noinst_LTLIBRARIES = libcompat.la
+@@ -189,35 +189,35 @@
+ 
+ include Makefile.am.arc4random
+ 
+-libcrypto_la_SOURCES =
+-EXTRA_libcrypto_la_SOURCES =
++liblibrecrypto_la_SOURCES =
++EXTRA_liblibrecrypto_la_SOURCES =
+ 
+ include Makefile.am.elf-x86_64
+ include Makefile.am.macosx-x86_64
+ 
+ if !HOST_ASM_ELF_X86_64
+ if !HOST_ASM_MACOSX_X86_64
+-libcrypto_la_SOURCES += aes/aes_cbc.c
+-libcrypto_la_SOURCES += aes/aes_core.c
+-libcrypto_la_SOURCES += camellia/camellia.c
+-libcrypto_la_SOURCES += camellia/cmll_cbc.c
+-libcrypto_la_SOURCES += rc4/rc4_enc.c
+-libcrypto_la_SOURCES += rc4/rc4_skey.c
+-libcrypto_la_SOURCES += whrlpool/wp_block.c
++liblibrecrypto_la_SOURCES += aes/aes_cbc.c
++liblibrecrypto_la_SOURCES += aes/aes_core.c
++liblibrecrypto_la_SOURCES += camellia/camellia.c
++liblibrecrypto_la_SOURCES += camellia/cmll_cbc.c
++liblibrecrypto_la_SOURCES += rc4/rc4_enc.c
++liblibrecrypto_la_SOURCES += rc4/rc4_skey.c
++liblibrecrypto_la_SOURCES += whrlpool/wp_block.c
+ endif
+ endif
+ 
+-libcrypto_la_SOURCES += cpt_err.c
+-libcrypto_la_SOURCES += cryptlib.c
+-libcrypto_la_SOURCES += crypto_init.c
+-libcrypto_la_SOURCES += cversion.c
+-libcrypto_la_SOURCES += ex_data.c
+-libcrypto_la_SOURCES += malloc-wrapper.c
+-libcrypto_la_SOURCES += mem_clr.c
+-libcrypto_la_SOURCES += mem_dbg.c
+-libcrypto_la_SOURCES += o_init.c
+-libcrypto_la_SOURCES += o_str.c
+-libcrypto_la_SOURCES += o_time.c
++liblibrecrypto_la_SOURCES += cpt_err.c
++liblibrecrypto_la_SOURCES += cryptlib.c
++liblibrecrypto_la_SOURCES += crypto_init.c
++liblibrecrypto_la_SOURCES += cversion.c
++liblibrecrypto_la_SOURCES += ex_data.c
++liblibrecrypto_la_SOURCES += malloc-wrapper.c
++liblibrecrypto_la_SOURCES += mem_clr.c
++liblibrecrypto_la_SOURCES += mem_dbg.c
++liblibrecrypto_la_SOURCES += o_init.c
++liblibrecrypto_la_SOURCES += o_str.c
++liblibrecrypto_la_SOURCES += o_time.c
+ noinst_HEADERS += constant_time_locl.h
+ noinst_HEADERS += cryptlib.h
+ noinst_HEADERS += md32_common.h
+@@ -225,685 +225,685 @@
+ noinst_HEADERS += x86_arch.h
+ 
+ # aes
+-libcrypto_la_SOURCES += aes/aes_cfb.c
+-libcrypto_la_SOURCES += aes/aes_ctr.c
+-libcrypto_la_SOURCES += aes/aes_ecb.c
+-libcrypto_la_SOURCES += aes/aes_ige.c
+-libcrypto_la_SOURCES += aes/aes_misc.c
+-libcrypto_la_SOURCES += aes/aes_ofb.c
+-libcrypto_la_SOURCES += aes/aes_wrap.c
++liblibrecrypto_la_SOURCES += aes/aes_cfb.c
++liblibrecrypto_la_SOURCES += aes/aes_ctr.c
++liblibrecrypto_la_SOURCES += aes/aes_ecb.c
++liblibrecrypto_la_SOURCES += aes/aes_ige.c
++liblibrecrypto_la_SOURCES += aes/aes_misc.c
++liblibrecrypto_la_SOURCES += aes/aes_ofb.c
++liblibrecrypto_la_SOURCES += aes/aes_wrap.c
+ noinst_HEADERS += aes/aes_locl.h
+ 
+ # asn1
+-libcrypto_la_SOURCES += asn1/a_bitstr.c
+-libcrypto_la_SOURCES += asn1/a_bool.c
+-libcrypto_la_SOURCES += asn1/a_bytes.c
+-libcrypto_la_SOURCES += asn1/a_d2i_fp.c
+-libcrypto_la_SOURCES += asn1/a_digest.c
+-libcrypto_la_SOURCES += asn1/a_dup.c
+-libcrypto_la_SOURCES += asn1/a_enum.c
+-libcrypto_la_SOURCES += asn1/a_i2d_fp.c
+-libcrypto_la_SOURCES += asn1/a_int.c
+-libcrypto_la_SOURCES += asn1/a_mbstr.c
+-libcrypto_la_SOURCES += asn1/a_object.c
+-libcrypto_la_SOURCES += asn1/a_octet.c
+-libcrypto_la_SOURCES += asn1/a_print.c
+-libcrypto_la_SOURCES += asn1/a_set.c
+-libcrypto_la_SOURCES += asn1/a_sign.c
+-libcrypto_la_SOURCES += asn1/a_strex.c
+-libcrypto_la_SOURCES += asn1/a_strnid.c
+-libcrypto_la_SOURCES += asn1/a_time.c
+-libcrypto_la_SOURCES += asn1/a_time_tm.c
+-libcrypto_la_SOURCES += asn1/a_type.c
+-libcrypto_la_SOURCES += asn1/a_utf8.c
+-libcrypto_la_SOURCES += asn1/a_verify.c
+-libcrypto_la_SOURCES += asn1/ameth_lib.c
+-libcrypto_la_SOURCES += asn1/asn1_err.c
+-libcrypto_la_SOURCES += asn1/asn1_gen.c
+-libcrypto_la_SOURCES += asn1/asn1_lib.c
+-libcrypto_la_SOURCES += asn1/asn1_par.c
+-libcrypto_la_SOURCES += asn1/asn_mime.c
+-libcrypto_la_SOURCES += asn1/asn_moid.c
+-libcrypto_la_SOURCES += asn1/asn_pack.c
+-libcrypto_la_SOURCES += asn1/bio_asn1.c
+-libcrypto_la_SOURCES += asn1/bio_ndef.c
+-libcrypto_la_SOURCES += asn1/d2i_pr.c
+-libcrypto_la_SOURCES += asn1/d2i_pu.c
+-libcrypto_la_SOURCES += asn1/evp_asn1.c
+-libcrypto_la_SOURCES += asn1/f_enum.c
+-libcrypto_la_SOURCES += asn1/f_int.c
+-libcrypto_la_SOURCES += asn1/f_string.c
+-libcrypto_la_SOURCES += asn1/i2d_pr.c
+-libcrypto_la_SOURCES += asn1/i2d_pu.c
+-libcrypto_la_SOURCES += asn1/n_pkey.c
+-libcrypto_la_SOURCES += asn1/nsseq.c
+-libcrypto_la_SOURCES += asn1/p5_pbe.c
+-libcrypto_la_SOURCES += asn1/p5_pbev2.c
+-libcrypto_la_SOURCES += asn1/p8_pkey.c
+-libcrypto_la_SOURCES += asn1/t_bitst.c
+-libcrypto_la_SOURCES += asn1/t_crl.c
+-libcrypto_la_SOURCES += asn1/t_pkey.c
+-libcrypto_la_SOURCES += asn1/t_req.c
+-libcrypto_la_SOURCES += asn1/t_spki.c
+-libcrypto_la_SOURCES += asn1/t_x509.c
+-libcrypto_la_SOURCES += asn1/t_x509a.c
+-libcrypto_la_SOURCES += asn1/tasn_dec.c
+-libcrypto_la_SOURCES += asn1/tasn_enc.c
+-libcrypto_la_SOURCES += asn1/tasn_fre.c
+-libcrypto_la_SOURCES += asn1/tasn_new.c
+-libcrypto_la_SOURCES += asn1/tasn_prn.c
+-libcrypto_la_SOURCES += asn1/tasn_typ.c
+-libcrypto_la_SOURCES += asn1/tasn_utl.c
+-libcrypto_la_SOURCES += asn1/x_algor.c
+-libcrypto_la_SOURCES += asn1/x_attrib.c
+-libcrypto_la_SOURCES += asn1/x_bignum.c
+-libcrypto_la_SOURCES += asn1/x_crl.c
+-libcrypto_la_SOURCES += asn1/x_exten.c
+-libcrypto_la_SOURCES += asn1/x_info.c
+-libcrypto_la_SOURCES += asn1/x_long.c
+-libcrypto_la_SOURCES += asn1/x_name.c
+-libcrypto_la_SOURCES += asn1/x_nx509.c
+-libcrypto_la_SOURCES += asn1/x_pkey.c
+-libcrypto_la_SOURCES += asn1/x_pubkey.c
+-libcrypto_la_SOURCES += asn1/x_req.c
+-libcrypto_la_SOURCES += asn1/x_sig.c
+-libcrypto_la_SOURCES += asn1/x_spki.c
+-libcrypto_la_SOURCES += asn1/x_val.c
+-libcrypto_la_SOURCES += asn1/x_x509.c
+-libcrypto_la_SOURCES += asn1/x_x509a.c
++liblibrecrypto_la_SOURCES += asn1/a_bitstr.c
++liblibrecrypto_la_SOURCES += asn1/a_bool.c
++liblibrecrypto_la_SOURCES += asn1/a_bytes.c
++liblibrecrypto_la_SOURCES += asn1/a_d2i_fp.c
++liblibrecrypto_la_SOURCES += asn1/a_digest.c
++liblibrecrypto_la_SOURCES += asn1/a_dup.c
++liblibrecrypto_la_SOURCES += asn1/a_enum.c
++liblibrecrypto_la_SOURCES += asn1/a_i2d_fp.c
++liblibrecrypto_la_SOURCES += asn1/a_int.c
++liblibrecrypto_la_SOURCES += asn1/a_mbstr.c
++liblibrecrypto_la_SOURCES += asn1/a_object.c
++liblibrecrypto_la_SOURCES += asn1/a_octet.c
++liblibrecrypto_la_SOURCES += asn1/a_print.c
++liblibrecrypto_la_SOURCES += asn1/a_set.c
++liblibrecrypto_la_SOURCES += asn1/a_sign.c
++liblibrecrypto_la_SOURCES += asn1/a_strex.c
++liblibrecrypto_la_SOURCES += asn1/a_strnid.c
++liblibrecrypto_la_SOURCES += asn1/a_time.c
++liblibrecrypto_la_SOURCES += asn1/a_time_tm.c
++liblibrecrypto_la_SOURCES += asn1/a_type.c
++liblibrecrypto_la_SOURCES += asn1/a_utf8.c
++liblibrecrypto_la_SOURCES += asn1/a_verify.c
++liblibrecrypto_la_SOURCES += asn1/ameth_lib.c
++liblibrecrypto_la_SOURCES += asn1/asn1_err.c
++liblibrecrypto_la_SOURCES += asn1/asn1_gen.c
++liblibrecrypto_la_SOURCES += asn1/asn1_lib.c
++liblibrecrypto_la_SOURCES += asn1/asn1_par.c
++liblibrecrypto_la_SOURCES += asn1/asn_mime.c
++liblibrecrypto_la_SOURCES += asn1/asn_moid.c
++liblibrecrypto_la_SOURCES += asn1/asn_pack.c
++liblibrecrypto_la_SOURCES += asn1/bio_asn1.c
++liblibrecrypto_la_SOURCES += asn1/bio_ndef.c
++liblibrecrypto_la_SOURCES += asn1/d2i_pr.c
++liblibrecrypto_la_SOURCES += asn1/d2i_pu.c
++liblibrecrypto_la_SOURCES += asn1/evp_asn1.c
++liblibrecrypto_la_SOURCES += asn1/f_enum.c
++liblibrecrypto_la_SOURCES += asn1/f_int.c
++liblibrecrypto_la_SOURCES += asn1/f_string.c
++liblibrecrypto_la_SOURCES += asn1/i2d_pr.c
++liblibrecrypto_la_SOURCES += asn1/i2d_pu.c
++liblibrecrypto_la_SOURCES += asn1/n_pkey.c
++liblibrecrypto_la_SOURCES += asn1/nsseq.c
++liblibrecrypto_la_SOURCES += asn1/p5_pbe.c
++liblibrecrypto_la_SOURCES += asn1/p5_pbev2.c
++liblibrecrypto_la_SOURCES += asn1/p8_pkey.c
++liblibrecrypto_la_SOURCES += asn1/t_bitst.c
++liblibrecrypto_la_SOURCES += asn1/t_crl.c
++liblibrecrypto_la_SOURCES += asn1/t_pkey.c
++liblibrecrypto_la_SOURCES += asn1/t_req.c
++liblibrecrypto_la_SOURCES += asn1/t_spki.c
++liblibrecrypto_la_SOURCES += asn1/t_x509.c
++liblibrecrypto_la_SOURCES += asn1/t_x509a.c
++liblibrecrypto_la_SOURCES += asn1/tasn_dec.c
++liblibrecrypto_la_SOURCES += asn1/tasn_enc.c
++liblibrecrypto_la_SOURCES += asn1/tasn_fre.c
++liblibrecrypto_la_SOURCES += asn1/tasn_new.c
++liblibrecrypto_la_SOURCES += asn1/tasn_prn.c
++liblibrecrypto_la_SOURCES += asn1/tasn_typ.c
++liblibrecrypto_la_SOURCES += asn1/tasn_utl.c
++liblibrecrypto_la_SOURCES += asn1/x_algor.c
++liblibrecrypto_la_SOURCES += asn1/x_attrib.c
++liblibrecrypto_la_SOURCES += asn1/x_bignum.c
++liblibrecrypto_la_SOURCES += asn1/x_crl.c
++liblibrecrypto_la_SOURCES += asn1/x_exten.c
++liblibrecrypto_la_SOURCES += asn1/x_info.c
++liblibrecrypto_la_SOURCES += asn1/x_long.c
++liblibrecrypto_la_SOURCES += asn1/x_name.c
++liblibrecrypto_la_SOURCES += asn1/x_nx509.c
++liblibrecrypto_la_SOURCES += asn1/x_pkey.c
++liblibrecrypto_la_SOURCES += asn1/x_pubkey.c
++liblibrecrypto_la_SOURCES += asn1/x_req.c
++liblibrecrypto_la_SOURCES += asn1/x_sig.c
++liblibrecrypto_la_SOURCES += asn1/x_spki.c
++liblibrecrypto_la_SOURCES += asn1/x_val.c
++liblibrecrypto_la_SOURCES += asn1/x_x509.c
++liblibrecrypto_la_SOURCES += asn1/x_x509a.c
+ noinst_HEADERS += asn1/asn1_locl.h
+ noinst_HEADERS += asn1/charmap.h
+ 
+ # bf
+-libcrypto_la_SOURCES += bf/bf_cfb64.c
+-libcrypto_la_SOURCES += bf/bf_ecb.c
+-libcrypto_la_SOURCES += bf/bf_enc.c
+-libcrypto_la_SOURCES += bf/bf_ofb64.c
+-libcrypto_la_SOURCES += bf/bf_skey.c
++liblibrecrypto_la_SOURCES += bf/bf_cfb64.c
++liblibrecrypto_la_SOURCES += bf/bf_ecb.c
++liblibrecrypto_la_SOURCES += bf/bf_enc.c
++liblibrecrypto_la_SOURCES += bf/bf_ofb64.c
++liblibrecrypto_la_SOURCES += bf/bf_skey.c
+ noinst_HEADERS += bf/bf_locl.h
+ noinst_HEADERS += bf/bf_pi.h
+ 
+ # bio
+-libcrypto_la_SOURCES += bio/b_dump.c
++liblibrecrypto_la_SOURCES += bio/b_dump.c
+ if !HOST_WIN
+-libcrypto_la_SOURCES += bio/b_posix.c
++liblibrecrypto_la_SOURCES += bio/b_posix.c
+ endif
+-libcrypto_la_SOURCES += bio/b_print.c
+-libcrypto_la_SOURCES += bio/b_sock.c
++liblibrecrypto_la_SOURCES += bio/b_print.c
++liblibrecrypto_la_SOURCES += bio/b_sock.c
+ if HOST_WIN
+-libcrypto_la_SOURCES += bio/b_win.c
++liblibrecrypto_la_SOURCES += bio/b_win.c
+ endif
+-libcrypto_la_SOURCES += bio/bf_buff.c
+-libcrypto_la_SOURCES += bio/bf_nbio.c
+-libcrypto_la_SOURCES += bio/bf_null.c
+-libcrypto_la_SOURCES += bio/bio_cb.c
+-libcrypto_la_SOURCES += bio/bio_err.c
+-libcrypto_la_SOURCES += bio/bio_lib.c
+-libcrypto_la_SOURCES += bio/bio_meth.c
+-libcrypto_la_SOURCES += bio/bss_acpt.c
+-libcrypto_la_SOURCES += bio/bss_bio.c
+-libcrypto_la_SOURCES += bio/bss_conn.c
+-libcrypto_la_SOURCES += bio/bss_dgram.c
+-libcrypto_la_SOURCES += bio/bss_fd.c
+-libcrypto_la_SOURCES += bio/bss_file.c
++liblibrecrypto_la_SOURCES += bio/bf_buff.c
++liblibrecrypto_la_SOURCES += bio/bf_nbio.c
++liblibrecrypto_la_SOURCES += bio/bf_null.c
++liblibrecrypto_la_SOURCES += bio/bio_cb.c
++liblibrecrypto_la_SOURCES += bio/bio_err.c
++liblibrecrypto_la_SOURCES += bio/bio_lib.c
++liblibrecrypto_la_SOURCES += bio/bio_meth.c
++liblibrecrypto_la_SOURCES += bio/bss_acpt.c
++liblibrecrypto_la_SOURCES += bio/bss_bio.c
++liblibrecrypto_la_SOURCES += bio/bss_conn.c
++liblibrecrypto_la_SOURCES += bio/bss_dgram.c
++liblibrecrypto_la_SOURCES += bio/bss_fd.c
++liblibrecrypto_la_SOURCES += bio/bss_file.c
+ if !HOST_WIN
+-libcrypto_la_SOURCES += bio/bss_log.c
++liblibrecrypto_la_SOURCES += bio/bss_log.c
+ endif
+-libcrypto_la_SOURCES += bio/bss_mem.c
+-libcrypto_la_SOURCES += bio/bss_null.c
+-libcrypto_la_SOURCES += bio/bss_sock.c
++liblibrecrypto_la_SOURCES += bio/bss_mem.c
++liblibrecrypto_la_SOURCES += bio/bss_null.c
++liblibrecrypto_la_SOURCES += bio/bss_sock.c
+ 
+ # bn
+-libcrypto_la_SOURCES += bn/bn_add.c
+-libcrypto_la_SOURCES += bn/bn_asm.c
+-libcrypto_la_SOURCES += bn/bn_blind.c
+-libcrypto_la_SOURCES += bn/bn_const.c
+-libcrypto_la_SOURCES += bn/bn_ctx.c
+-libcrypto_la_SOURCES += bn/bn_depr.c
+-libcrypto_la_SOURCES += bn/bn_div.c
+-libcrypto_la_SOURCES += bn/bn_err.c
+-libcrypto_la_SOURCES += bn/bn_exp.c
+-libcrypto_la_SOURCES += bn/bn_exp2.c
+-libcrypto_la_SOURCES += bn/bn_gcd.c
+-libcrypto_la_SOURCES += bn/bn_gf2m.c
+-libcrypto_la_SOURCES += bn/bn_kron.c
+-libcrypto_la_SOURCES += bn/bn_lib.c
+-libcrypto_la_SOURCES += bn/bn_mod.c
+-libcrypto_la_SOURCES += bn/bn_mont.c
+-libcrypto_la_SOURCES += bn/bn_mpi.c
+-libcrypto_la_SOURCES += bn/bn_mul.c
+-libcrypto_la_SOURCES += bn/bn_nist.c
+-libcrypto_la_SOURCES += bn/bn_prime.c
+-libcrypto_la_SOURCES += bn/bn_print.c
+-libcrypto_la_SOURCES += bn/bn_rand.c
+-libcrypto_la_SOURCES += bn/bn_recp.c
+-libcrypto_la_SOURCES += bn/bn_shift.c
+-libcrypto_la_SOURCES += bn/bn_sqr.c
+-libcrypto_la_SOURCES += bn/bn_sqrt.c
+-libcrypto_la_SOURCES += bn/bn_word.c
+-libcrypto_la_SOURCES += bn/bn_x931p.c
++liblibrecrypto_la_SOURCES += bn/bn_add.c
++liblibrecrypto_la_SOURCES += bn/bn_asm.c
++liblibrecrypto_la_SOURCES += bn/bn_blind.c
++liblibrecrypto_la_SOURCES += bn/bn_const.c
++liblibrecrypto_la_SOURCES += bn/bn_ctx.c
++liblibrecrypto_la_SOURCES += bn/bn_depr.c
++liblibrecrypto_la_SOURCES += bn/bn_div.c
++liblibrecrypto_la_SOURCES += bn/bn_err.c
++liblibrecrypto_la_SOURCES += bn/bn_exp.c
++liblibrecrypto_la_SOURCES += bn/bn_exp2.c
++liblibrecrypto_la_SOURCES += bn/bn_gcd.c
++liblibrecrypto_la_SOURCES += bn/bn_gf2m.c
++liblibrecrypto_la_SOURCES += bn/bn_kron.c
++liblibrecrypto_la_SOURCES += bn/bn_lib.c
++liblibrecrypto_la_SOURCES += bn/bn_mod.c
++liblibrecrypto_la_SOURCES += bn/bn_mont.c
++liblibrecrypto_la_SOURCES += bn/bn_mpi.c
++liblibrecrypto_la_SOURCES += bn/bn_mul.c
++liblibrecrypto_la_SOURCES += bn/bn_nist.c
++liblibrecrypto_la_SOURCES += bn/bn_prime.c
++liblibrecrypto_la_SOURCES += bn/bn_print.c
++liblibrecrypto_la_SOURCES += bn/bn_rand.c
++liblibrecrypto_la_SOURCES += bn/bn_recp.c
++liblibrecrypto_la_SOURCES += bn/bn_shift.c
++liblibrecrypto_la_SOURCES += bn/bn_sqr.c
++liblibrecrypto_la_SOURCES += bn/bn_sqrt.c
++liblibrecrypto_la_SOURCES += bn/bn_word.c
++liblibrecrypto_la_SOURCES += bn/bn_x931p.c
+ noinst_HEADERS += bn/bn_lcl.h
+ noinst_HEADERS += bn/bn_prime.h
+ 
+ # buffer
+-libcrypto_la_SOURCES += buffer/buf_err.c
+-libcrypto_la_SOURCES += buffer/buf_str.c
+-libcrypto_la_SOURCES += buffer/buffer.c
++liblibrecrypto_la_SOURCES += buffer/buf_err.c
++liblibrecrypto_la_SOURCES += buffer/buf_str.c
++liblibrecrypto_la_SOURCES += buffer/buffer.c
+ 
+ # camellia
+-libcrypto_la_SOURCES += camellia/cmll_cfb.c
+-libcrypto_la_SOURCES += camellia/cmll_ctr.c
+-libcrypto_la_SOURCES += camellia/cmll_ecb.c
+-libcrypto_la_SOURCES += camellia/cmll_misc.c
+-libcrypto_la_SOURCES += camellia/cmll_ofb.c
++liblibrecrypto_la_SOURCES += camellia/cmll_cfb.c
++liblibrecrypto_la_SOURCES += camellia/cmll_ctr.c
++liblibrecrypto_la_SOURCES += camellia/cmll_ecb.c
++liblibrecrypto_la_SOURCES += camellia/cmll_misc.c
++liblibrecrypto_la_SOURCES += camellia/cmll_ofb.c
+ noinst_HEADERS += camellia/camellia.h
+ noinst_HEADERS += camellia/cmll_locl.h
+ 
+ # cast
+-libcrypto_la_SOURCES += cast/c_cfb64.c
+-libcrypto_la_SOURCES += cast/c_ecb.c
+-libcrypto_la_SOURCES += cast/c_enc.c
+-libcrypto_la_SOURCES += cast/c_ofb64.c
+-libcrypto_la_SOURCES += cast/c_skey.c
++liblibrecrypto_la_SOURCES += cast/c_cfb64.c
++liblibrecrypto_la_SOURCES += cast/c_ecb.c
++liblibrecrypto_la_SOURCES += cast/c_enc.c
++liblibrecrypto_la_SOURCES += cast/c_ofb64.c
++liblibrecrypto_la_SOURCES += cast/c_skey.c
+ noinst_HEADERS += cast/cast_lcl.h
+ noinst_HEADERS += cast/cast_s.h
+ 
+ # chacha
+-EXTRA_libcrypto_la_SOURCES += chacha/chacha-merged.c
+-libcrypto_la_SOURCES += chacha/chacha.c
++EXTRA_liblibrecrypto_la_SOURCES += chacha/chacha-merged.c
++liblibrecrypto_la_SOURCES += chacha/chacha.c
+ 
+ # cmac
+-libcrypto_la_SOURCES += cmac/cm_ameth.c
+-libcrypto_la_SOURCES += cmac/cm_pmeth.c
+-libcrypto_la_SOURCES += cmac/cmac.c
++liblibrecrypto_la_SOURCES += cmac/cm_ameth.c
++liblibrecrypto_la_SOURCES += cmac/cm_pmeth.c
++liblibrecrypto_la_SOURCES += cmac/cmac.c
+ 
+ # comp
+-libcrypto_la_SOURCES += comp/c_rle.c
+-libcrypto_la_SOURCES += comp/c_zlib.c
+-libcrypto_la_SOURCES += comp/comp_err.c
+-libcrypto_la_SOURCES += comp/comp_lib.c
++liblibrecrypto_la_SOURCES += comp/c_rle.c
++liblibrecrypto_la_SOURCES += comp/c_zlib.c
++liblibrecrypto_la_SOURCES += comp/comp_err.c
++liblibrecrypto_la_SOURCES += comp/comp_lib.c
+ 
+ # conf
+-libcrypto_la_SOURCES += conf/conf_api.c
+-libcrypto_la_SOURCES += conf/conf_def.c
+-libcrypto_la_SOURCES += conf/conf_err.c
+-libcrypto_la_SOURCES += conf/conf_lib.c
+-libcrypto_la_SOURCES += conf/conf_mall.c
+-libcrypto_la_SOURCES += conf/conf_mod.c
+-libcrypto_la_SOURCES += conf/conf_sap.c
++liblibrecrypto_la_SOURCES += conf/conf_api.c
++liblibrecrypto_la_SOURCES += conf/conf_def.c
++liblibrecrypto_la_SOURCES += conf/conf_err.c
++liblibrecrypto_la_SOURCES += conf/conf_lib.c
++liblibrecrypto_la_SOURCES += conf/conf_mall.c
++liblibrecrypto_la_SOURCES += conf/conf_mod.c
++liblibrecrypto_la_SOURCES += conf/conf_sap.c
+ noinst_HEADERS += conf/conf_def.h
+ 
+ # curve25519
+-libcrypto_la_SOURCES += curve25519/curve25519-generic.c
+-libcrypto_la_SOURCES += curve25519/curve25519.c
++liblibrecrypto_la_SOURCES += curve25519/curve25519-generic.c
++liblibrecrypto_la_SOURCES += curve25519/curve25519.c
+ noinst_HEADERS += curve25519/curve25519_internal.h
+ 
+ 
+ # des
+-libcrypto_la_SOURCES += des/cbc_cksm.c
+-libcrypto_la_SOURCES += des/cbc_enc.c
+-libcrypto_la_SOURCES += des/cfb64ede.c
+-libcrypto_la_SOURCES += des/cfb64enc.c
+-libcrypto_la_SOURCES += des/cfb_enc.c
+-libcrypto_la_SOURCES += des/des_enc.c
+-libcrypto_la_SOURCES += des/ecb3_enc.c
+-libcrypto_la_SOURCES += des/ecb_enc.c
+-libcrypto_la_SOURCES += des/ede_cbcm_enc.c
+-libcrypto_la_SOURCES += des/enc_read.c
+-libcrypto_la_SOURCES += des/enc_writ.c
+-libcrypto_la_SOURCES += des/fcrypt.c
+-libcrypto_la_SOURCES += des/fcrypt_b.c
+-EXTRA_libcrypto_la_SOURCES += des/ncbc_enc.c
+-libcrypto_la_SOURCES += des/ofb64ede.c
+-libcrypto_la_SOURCES += des/ofb64enc.c
+-libcrypto_la_SOURCES += des/ofb_enc.c
+-libcrypto_la_SOURCES += des/pcbc_enc.c
+-libcrypto_la_SOURCES += des/qud_cksm.c
+-libcrypto_la_SOURCES += des/rand_key.c
+-libcrypto_la_SOURCES += des/set_key.c
+-libcrypto_la_SOURCES += des/str2key.c
+-libcrypto_la_SOURCES += des/xcbc_enc.c
++liblibrecrypto_la_SOURCES += des/cbc_cksm.c
++liblibrecrypto_la_SOURCES += des/cbc_enc.c
++liblibrecrypto_la_SOURCES += des/cfb64ede.c
++liblibrecrypto_la_SOURCES += des/cfb64enc.c
++liblibrecrypto_la_SOURCES += des/cfb_enc.c
++liblibrecrypto_la_SOURCES += des/des_enc.c
++liblibrecrypto_la_SOURCES += des/ecb3_enc.c
++liblibrecrypto_la_SOURCES += des/ecb_enc.c
++liblibrecrypto_la_SOURCES += des/ede_cbcm_enc.c
++liblibrecrypto_la_SOURCES += des/enc_read.c
++liblibrecrypto_la_SOURCES += des/enc_writ.c
++liblibrecrypto_la_SOURCES += des/fcrypt.c
++liblibrecrypto_la_SOURCES += des/fcrypt_b.c
++EXTRA_liblibrecrypto_la_SOURCES += des/ncbc_enc.c
++liblibrecrypto_la_SOURCES += des/ofb64ede.c
++liblibrecrypto_la_SOURCES += des/ofb64enc.c
++liblibrecrypto_la_SOURCES += des/ofb_enc.c
++liblibrecrypto_la_SOURCES += des/pcbc_enc.c
++liblibrecrypto_la_SOURCES += des/qud_cksm.c
++liblibrecrypto_la_SOURCES += des/rand_key.c
++liblibrecrypto_la_SOURCES += des/set_key.c
++liblibrecrypto_la_SOURCES += des/str2key.c
++liblibrecrypto_la_SOURCES += des/xcbc_enc.c
+ noinst_HEADERS += des/des_locl.h
+ noinst_HEADERS += des/spr.h
+ 
+ # dh
+-libcrypto_la_SOURCES += dh/dh_ameth.c
+-libcrypto_la_SOURCES += dh/dh_asn1.c
+-libcrypto_la_SOURCES += dh/dh_check.c
+-libcrypto_la_SOURCES += dh/dh_depr.c
+-libcrypto_la_SOURCES += dh/dh_err.c
+-libcrypto_la_SOURCES += dh/dh_gen.c
+-libcrypto_la_SOURCES += dh/dh_key.c
+-libcrypto_la_SOURCES += dh/dh_lib.c
+-libcrypto_la_SOURCES += dh/dh_pmeth.c
+-libcrypto_la_SOURCES += dh/dh_prn.c
++liblibrecrypto_la_SOURCES += dh/dh_ameth.c
++liblibrecrypto_la_SOURCES += dh/dh_asn1.c
++liblibrecrypto_la_SOURCES += dh/dh_check.c
++liblibrecrypto_la_SOURCES += dh/dh_depr.c
++liblibrecrypto_la_SOURCES += dh/dh_err.c
++liblibrecrypto_la_SOURCES += dh/dh_gen.c
++liblibrecrypto_la_SOURCES += dh/dh_key.c
++liblibrecrypto_la_SOURCES += dh/dh_lib.c
++liblibrecrypto_la_SOURCES += dh/dh_pmeth.c
++liblibrecrypto_la_SOURCES += dh/dh_prn.c
+ 
+ # dsa
+-libcrypto_la_SOURCES += dsa/dsa_ameth.c
+-libcrypto_la_SOURCES += dsa/dsa_asn1.c
+-libcrypto_la_SOURCES += dsa/dsa_depr.c
+-libcrypto_la_SOURCES += dsa/dsa_err.c
+-libcrypto_la_SOURCES += dsa/dsa_gen.c
+-libcrypto_la_SOURCES += dsa/dsa_key.c
+-libcrypto_la_SOURCES += dsa/dsa_lib.c
+-libcrypto_la_SOURCES += dsa/dsa_meth.c
+-libcrypto_la_SOURCES += dsa/dsa_ossl.c
+-libcrypto_la_SOURCES += dsa/dsa_pmeth.c
+-libcrypto_la_SOURCES += dsa/dsa_prn.c
+-libcrypto_la_SOURCES += dsa/dsa_sign.c
+-libcrypto_la_SOURCES += dsa/dsa_vrf.c
++liblibrecrypto_la_SOURCES += dsa/dsa_ameth.c
++liblibrecrypto_la_SOURCES += dsa/dsa_asn1.c
++liblibrecrypto_la_SOURCES += dsa/dsa_depr.c
++liblibrecrypto_la_SOURCES += dsa/dsa_err.c
++liblibrecrypto_la_SOURCES += dsa/dsa_gen.c
++liblibrecrypto_la_SOURCES += dsa/dsa_key.c
++liblibrecrypto_la_SOURCES += dsa/dsa_lib.c
++liblibrecrypto_la_SOURCES += dsa/dsa_meth.c
++liblibrecrypto_la_SOURCES += dsa/dsa_ossl.c
++liblibrecrypto_la_SOURCES += dsa/dsa_pmeth.c
++liblibrecrypto_la_SOURCES += dsa/dsa_prn.c
++liblibrecrypto_la_SOURCES += dsa/dsa_sign.c
++liblibrecrypto_la_SOURCES += dsa/dsa_vrf.c
+ noinst_HEADERS += dsa/dsa_locl.h
+ 
+ # dso
+-libcrypto_la_SOURCES += dso/dso_dlfcn.c
+-libcrypto_la_SOURCES += dso/dso_err.c
+-libcrypto_la_SOURCES += dso/dso_lib.c
+-libcrypto_la_SOURCES += dso/dso_null.c
+-libcrypto_la_SOURCES += dso/dso_openssl.c
++liblibrecrypto_la_SOURCES += dso/dso_dlfcn.c
++liblibrecrypto_la_SOURCES += dso/dso_err.c
++liblibrecrypto_la_SOURCES += dso/dso_lib.c
++liblibrecrypto_la_SOURCES += dso/dso_null.c
++liblibrecrypto_la_SOURCES += dso/dso_openssl.c
+ 
+ # ec
+-libcrypto_la_SOURCES += ec/ec2_mult.c
+-libcrypto_la_SOURCES += ec/ec2_oct.c
+-libcrypto_la_SOURCES += ec/ec2_smpl.c
+-libcrypto_la_SOURCES += ec/ec_ameth.c
+-libcrypto_la_SOURCES += ec/ec_asn1.c
+-libcrypto_la_SOURCES += ec/ec_check.c
+-libcrypto_la_SOURCES += ec/ec_curve.c
+-libcrypto_la_SOURCES += ec/ec_cvt.c
+-libcrypto_la_SOURCES += ec/ec_err.c
+-libcrypto_la_SOURCES += ec/ec_key.c
+-libcrypto_la_SOURCES += ec/ec_lib.c
+-libcrypto_la_SOURCES += ec/ec_mult.c
+-libcrypto_la_SOURCES += ec/ec_oct.c
+-libcrypto_la_SOURCES += ec/ec_pmeth.c
+-libcrypto_la_SOURCES += ec/ec_print.c
+-libcrypto_la_SOURCES += ec/eck_prn.c
+-libcrypto_la_SOURCES += ec/ecp_mont.c
+-libcrypto_la_SOURCES += ec/ecp_nist.c
+-libcrypto_la_SOURCES += ec/ecp_oct.c
+-libcrypto_la_SOURCES += ec/ecp_smpl.c
++liblibrecrypto_la_SOURCES += ec/ec2_mult.c
++liblibrecrypto_la_SOURCES += ec/ec2_oct.c
++liblibrecrypto_la_SOURCES += ec/ec2_smpl.c
++liblibrecrypto_la_SOURCES += ec/ec_ameth.c
++liblibrecrypto_la_SOURCES += ec/ec_asn1.c
++liblibrecrypto_la_SOURCES += ec/ec_check.c
++liblibrecrypto_la_SOURCES += ec/ec_curve.c
++liblibrecrypto_la_SOURCES += ec/ec_cvt.c
++liblibrecrypto_la_SOURCES += ec/ec_err.c
++liblibrecrypto_la_SOURCES += ec/ec_key.c
++liblibrecrypto_la_SOURCES += ec/ec_lib.c
++liblibrecrypto_la_SOURCES += ec/ec_mult.c
++liblibrecrypto_la_SOURCES += ec/ec_oct.c
++liblibrecrypto_la_SOURCES += ec/ec_pmeth.c
++liblibrecrypto_la_SOURCES += ec/ec_print.c
++liblibrecrypto_la_SOURCES += ec/eck_prn.c
++liblibrecrypto_la_SOURCES += ec/ecp_mont.c
++liblibrecrypto_la_SOURCES += ec/ecp_nist.c
++liblibrecrypto_la_SOURCES += ec/ecp_oct.c
++liblibrecrypto_la_SOURCES += ec/ecp_smpl.c
+ noinst_HEADERS += ec/ec_lcl.h
+ 
+ # ecdh
+-libcrypto_la_SOURCES += ecdh/ech_err.c
+-libcrypto_la_SOURCES += ecdh/ech_key.c
+-libcrypto_la_SOURCES += ecdh/ech_lib.c
++liblibrecrypto_la_SOURCES += ecdh/ech_err.c
++liblibrecrypto_la_SOURCES += ecdh/ech_key.c
++liblibrecrypto_la_SOURCES += ecdh/ech_lib.c
+ noinst_HEADERS += ecdh/ech_locl.h
+ 
+ # ecdsa
+-libcrypto_la_SOURCES += ecdsa/ecs_asn1.c
+-libcrypto_la_SOURCES += ecdsa/ecs_err.c
+-libcrypto_la_SOURCES += ecdsa/ecs_lib.c
+-libcrypto_la_SOURCES += ecdsa/ecs_ossl.c
+-libcrypto_la_SOURCES += ecdsa/ecs_sign.c
+-libcrypto_la_SOURCES += ecdsa/ecs_vrf.c
++liblibrecrypto_la_SOURCES += ecdsa/ecs_asn1.c
++liblibrecrypto_la_SOURCES += ecdsa/ecs_err.c
++liblibrecrypto_la_SOURCES += ecdsa/ecs_lib.c
++liblibrecrypto_la_SOURCES += ecdsa/ecs_ossl.c
++liblibrecrypto_la_SOURCES += ecdsa/ecs_sign.c
++liblibrecrypto_la_SOURCES += ecdsa/ecs_vrf.c
+ noinst_HEADERS += ecdsa/ecs_locl.h
+ 
+ # engine
+-libcrypto_la_SOURCES += engine/eng_all.c
+-libcrypto_la_SOURCES += engine/eng_cnf.c
+-libcrypto_la_SOURCES += engine/eng_ctrl.c
+-libcrypto_la_SOURCES += engine/eng_dyn.c
+-libcrypto_la_SOURCES += engine/eng_err.c
+-libcrypto_la_SOURCES += engine/eng_fat.c
+-libcrypto_la_SOURCES += engine/eng_init.c
+-libcrypto_la_SOURCES += engine/eng_lib.c
+-libcrypto_la_SOURCES += engine/eng_list.c
+-libcrypto_la_SOURCES += engine/eng_openssl.c
+-libcrypto_la_SOURCES += engine/eng_pkey.c
+-libcrypto_la_SOURCES += engine/eng_table.c
+-libcrypto_la_SOURCES += engine/tb_asnmth.c
+-libcrypto_la_SOURCES += engine/tb_cipher.c
+-libcrypto_la_SOURCES += engine/tb_dh.c
+-libcrypto_la_SOURCES += engine/tb_digest.c
+-libcrypto_la_SOURCES += engine/tb_dsa.c
+-libcrypto_la_SOURCES += engine/tb_ecdh.c
+-libcrypto_la_SOURCES += engine/tb_ecdsa.c
+-libcrypto_la_SOURCES += engine/tb_pkmeth.c
+-libcrypto_la_SOURCES += engine/tb_rand.c
+-libcrypto_la_SOURCES += engine/tb_rsa.c
+-libcrypto_la_SOURCES += engine/tb_store.c
++liblibrecrypto_la_SOURCES += engine/eng_all.c
++liblibrecrypto_la_SOURCES += engine/eng_cnf.c
++liblibrecrypto_la_SOURCES += engine/eng_ctrl.c
++liblibrecrypto_la_SOURCES += engine/eng_dyn.c
++liblibrecrypto_la_SOURCES += engine/eng_err.c
++liblibrecrypto_la_SOURCES += engine/eng_fat.c
++liblibrecrypto_la_SOURCES += engine/eng_init.c
++liblibrecrypto_la_SOURCES += engine/eng_lib.c
++liblibrecrypto_la_SOURCES += engine/eng_list.c
++liblibrecrypto_la_SOURCES += engine/eng_openssl.c
++liblibrecrypto_la_SOURCES += engine/eng_pkey.c
++liblibrecrypto_la_SOURCES += engine/eng_table.c
++liblibrecrypto_la_SOURCES += engine/tb_asnmth.c
++liblibrecrypto_la_SOURCES += engine/tb_cipher.c
++liblibrecrypto_la_SOURCES += engine/tb_dh.c
++liblibrecrypto_la_SOURCES += engine/tb_digest.c
++liblibrecrypto_la_SOURCES += engine/tb_dsa.c
++liblibrecrypto_la_SOURCES += engine/tb_ecdh.c
++liblibrecrypto_la_SOURCES += engine/tb_ecdsa.c
++liblibrecrypto_la_SOURCES += engine/tb_pkmeth.c
++liblibrecrypto_la_SOURCES += engine/tb_rand.c
++liblibrecrypto_la_SOURCES += engine/tb_rsa.c
++liblibrecrypto_la_SOURCES += engine/tb_store.c
+ noinst_HEADERS += engine/eng_int.h
+ 
+ # err
+-libcrypto_la_SOURCES += err/err.c
+-libcrypto_la_SOURCES += err/err_all.c
+-libcrypto_la_SOURCES += err/err_prn.c
++liblibrecrypto_la_SOURCES += err/err.c
++liblibrecrypto_la_SOURCES += err/err_all.c
++liblibrecrypto_la_SOURCES += err/err_prn.c
+ 
+ # evp
+-libcrypto_la_SOURCES += evp/bio_b64.c
+-libcrypto_la_SOURCES += evp/bio_enc.c
+-libcrypto_la_SOURCES += evp/bio_md.c
+-libcrypto_la_SOURCES += evp/c_all.c
+-libcrypto_la_SOURCES += evp/digest.c
+-libcrypto_la_SOURCES += evp/e_aes.c
+-libcrypto_la_SOURCES += evp/e_aes_cbc_hmac_sha1.c
+-libcrypto_la_SOURCES += evp/e_bf.c
+-libcrypto_la_SOURCES += evp/e_camellia.c
+-libcrypto_la_SOURCES += evp/e_cast.c
+-libcrypto_la_SOURCES += evp/e_chacha.c
+-libcrypto_la_SOURCES += evp/e_chacha20poly1305.c
+-libcrypto_la_SOURCES += evp/e_des.c
+-libcrypto_la_SOURCES += evp/e_des3.c
+-libcrypto_la_SOURCES += evp/e_gost2814789.c
+-libcrypto_la_SOURCES += evp/e_idea.c
+-libcrypto_la_SOURCES += evp/e_null.c
+-libcrypto_la_SOURCES += evp/e_old.c
+-libcrypto_la_SOURCES += evp/e_rc2.c
+-libcrypto_la_SOURCES += evp/e_rc4.c
+-libcrypto_la_SOURCES += evp/e_rc4_hmac_md5.c
+-libcrypto_la_SOURCES += evp/e_xcbc_d.c
+-libcrypto_la_SOURCES += evp/encode.c
+-libcrypto_la_SOURCES += evp/evp_aead.c
+-libcrypto_la_SOURCES += evp/evp_enc.c
+-libcrypto_la_SOURCES += evp/evp_err.c
+-libcrypto_la_SOURCES += evp/evp_key.c
+-libcrypto_la_SOURCES += evp/evp_lib.c
+-libcrypto_la_SOURCES += evp/evp_pbe.c
+-libcrypto_la_SOURCES += evp/evp_pkey.c
+-libcrypto_la_SOURCES += evp/m_dss.c
+-libcrypto_la_SOURCES += evp/m_dss1.c
+-libcrypto_la_SOURCES += evp/m_ecdsa.c
+-libcrypto_la_SOURCES += evp/m_gost2814789.c
+-libcrypto_la_SOURCES += evp/m_gostr341194.c
+-libcrypto_la_SOURCES += evp/m_md4.c
+-libcrypto_la_SOURCES += evp/m_md5.c
+-libcrypto_la_SOURCES += evp/m_md5_sha1.c
+-libcrypto_la_SOURCES += evp/m_null.c
+-libcrypto_la_SOURCES += evp/m_ripemd.c
+-libcrypto_la_SOURCES += evp/m_sha1.c
+-libcrypto_la_SOURCES += evp/m_sigver.c
+-libcrypto_la_SOURCES += evp/m_streebog.c
+-libcrypto_la_SOURCES += evp/m_wp.c
+-libcrypto_la_SOURCES += evp/names.c
+-libcrypto_la_SOURCES += evp/p5_crpt.c
+-libcrypto_la_SOURCES += evp/p5_crpt2.c
+-libcrypto_la_SOURCES += evp/p_dec.c
+-libcrypto_la_SOURCES += evp/p_enc.c
+-libcrypto_la_SOURCES += evp/p_lib.c
+-libcrypto_la_SOURCES += evp/p_open.c
+-libcrypto_la_SOURCES += evp/p_seal.c
+-libcrypto_la_SOURCES += evp/p_sign.c
+-libcrypto_la_SOURCES += evp/p_verify.c
+-libcrypto_la_SOURCES += evp/pmeth_fn.c
+-libcrypto_la_SOURCES += evp/pmeth_gn.c
+-libcrypto_la_SOURCES += evp/pmeth_lib.c
++liblibrecrypto_la_SOURCES += evp/bio_b64.c
++liblibrecrypto_la_SOURCES += evp/bio_enc.c
++liblibrecrypto_la_SOURCES += evp/bio_md.c
++liblibrecrypto_la_SOURCES += evp/c_all.c
++liblibrecrypto_la_SOURCES += evp/digest.c
++liblibrecrypto_la_SOURCES += evp/e_aes.c
++liblibrecrypto_la_SOURCES += evp/e_aes_cbc_hmac_sha1.c
++liblibrecrypto_la_SOURCES += evp/e_bf.c
++liblibrecrypto_la_SOURCES += evp/e_camellia.c
++liblibrecrypto_la_SOURCES += evp/e_cast.c
++liblibrecrypto_la_SOURCES += evp/e_chacha.c
++liblibrecrypto_la_SOURCES += evp/e_chacha20poly1305.c
++liblibrecrypto_la_SOURCES += evp/e_des.c
++liblibrecrypto_la_SOURCES += evp/e_des3.c
++liblibrecrypto_la_SOURCES += evp/e_gost2814789.c
++liblibrecrypto_la_SOURCES += evp/e_idea.c
++liblibrecrypto_la_SOURCES += evp/e_null.c
++liblibrecrypto_la_SOURCES += evp/e_old.c
++liblibrecrypto_la_SOURCES += evp/e_rc2.c
++liblibrecrypto_la_SOURCES += evp/e_rc4.c
++liblibrecrypto_la_SOURCES += evp/e_rc4_hmac_md5.c
++liblibrecrypto_la_SOURCES += evp/e_xcbc_d.c
++liblibrecrypto_la_SOURCES += evp/encode.c
++liblibrecrypto_la_SOURCES += evp/evp_aead.c
++liblibrecrypto_la_SOURCES += evp/evp_enc.c
++liblibrecrypto_la_SOURCES += evp/evp_err.c
++liblibrecrypto_la_SOURCES += evp/evp_key.c
++liblibrecrypto_la_SOURCES += evp/evp_lib.c
++liblibrecrypto_la_SOURCES += evp/evp_pbe.c
++liblibrecrypto_la_SOURCES += evp/evp_pkey.c
++liblibrecrypto_la_SOURCES += evp/m_dss.c
++liblibrecrypto_la_SOURCES += evp/m_dss1.c
++liblibrecrypto_la_SOURCES += evp/m_ecdsa.c
++liblibrecrypto_la_SOURCES += evp/m_gost2814789.c
++liblibrecrypto_la_SOURCES += evp/m_gostr341194.c
++liblibrecrypto_la_SOURCES += evp/m_md4.c
++liblibrecrypto_la_SOURCES += evp/m_md5.c
++liblibrecrypto_la_SOURCES += evp/m_md5_sha1.c
++liblibrecrypto_la_SOURCES += evp/m_null.c
++liblibrecrypto_la_SOURCES += evp/m_ripemd.c
++liblibrecrypto_la_SOURCES += evp/m_sha1.c
++liblibrecrypto_la_SOURCES += evp/m_sigver.c
++liblibrecrypto_la_SOURCES += evp/m_streebog.c
++liblibrecrypto_la_SOURCES += evp/m_wp.c
++liblibrecrypto_la_SOURCES += evp/names.c
++liblibrecrypto_la_SOURCES += evp/p5_crpt.c
++liblibrecrypto_la_SOURCES += evp/p5_crpt2.c
++liblibrecrypto_la_SOURCES += evp/p_dec.c
++liblibrecrypto_la_SOURCES += evp/p_enc.c
++liblibrecrypto_la_SOURCES += evp/p_lib.c
++liblibrecrypto_la_SOURCES += evp/p_open.c
++liblibrecrypto_la_SOURCES += evp/p_seal.c
++liblibrecrypto_la_SOURCES += evp/p_sign.c
++liblibrecrypto_la_SOURCES += evp/p_verify.c
++liblibrecrypto_la_SOURCES += evp/pmeth_fn.c
++liblibrecrypto_la_SOURCES += evp/pmeth_gn.c
++liblibrecrypto_la_SOURCES += evp/pmeth_lib.c
+ noinst_HEADERS += evp/evp_locl.h
+ 
+ # gost
+-libcrypto_la_SOURCES += gost/gost2814789.c
+-libcrypto_la_SOURCES += gost/gost89_keywrap.c
+-libcrypto_la_SOURCES += gost/gost89_params.c
+-libcrypto_la_SOURCES += gost/gost89imit_ameth.c
+-libcrypto_la_SOURCES += gost/gost89imit_pmeth.c
+-libcrypto_la_SOURCES += gost/gost_asn1.c
+-libcrypto_la_SOURCES += gost/gost_err.c
+-libcrypto_la_SOURCES += gost/gostr341001.c
+-libcrypto_la_SOURCES += gost/gostr341001_ameth.c
+-libcrypto_la_SOURCES += gost/gostr341001_key.c
+-libcrypto_la_SOURCES += gost/gostr341001_params.c
+-libcrypto_la_SOURCES += gost/gostr341001_pmeth.c
+-libcrypto_la_SOURCES += gost/gostr341194.c
+-libcrypto_la_SOURCES += gost/streebog.c
++liblibrecrypto_la_SOURCES += gost/gost2814789.c
++liblibrecrypto_la_SOURCES += gost/gost89_keywrap.c
++liblibrecrypto_la_SOURCES += gost/gost89_params.c
++liblibrecrypto_la_SOURCES += gost/gost89imit_ameth.c
++liblibrecrypto_la_SOURCES += gost/gost89imit_pmeth.c
++liblibrecrypto_la_SOURCES += gost/gost_asn1.c
++liblibrecrypto_la_SOURCES += gost/gost_err.c
++liblibrecrypto_la_SOURCES += gost/gostr341001.c
++liblibrecrypto_la_SOURCES += gost/gostr341001_ameth.c
++liblibrecrypto_la_SOURCES += gost/gostr341001_key.c
++liblibrecrypto_la_SOURCES += gost/gostr341001_params.c
++liblibrecrypto_la_SOURCES += gost/gostr341001_pmeth.c
++liblibrecrypto_la_SOURCES += gost/gostr341194.c
++liblibrecrypto_la_SOURCES += gost/streebog.c
+ noinst_HEADERS += gost/gost.h
+ noinst_HEADERS += gost/gost_asn1.h
+ noinst_HEADERS += gost/gost_locl.h
+ 
+ # hkdf
+-libcrypto_la_SOURCES += hkdf/hkdf.c
++liblibrecrypto_la_SOURCES += hkdf/hkdf.c
+ 
+ # hmac
+-libcrypto_la_SOURCES += hmac/hm_ameth.c
+-libcrypto_la_SOURCES += hmac/hm_pmeth.c
+-libcrypto_la_SOURCES += hmac/hmac.c
++liblibrecrypto_la_SOURCES += hmac/hm_ameth.c
++liblibrecrypto_la_SOURCES += hmac/hm_pmeth.c
++liblibrecrypto_la_SOURCES += hmac/hmac.c
+ 
+ # idea
+-libcrypto_la_SOURCES += idea/i_cbc.c
+-libcrypto_la_SOURCES += idea/i_cfb64.c
+-libcrypto_la_SOURCES += idea/i_ecb.c
+-libcrypto_la_SOURCES += idea/i_ofb64.c
+-libcrypto_la_SOURCES += idea/i_skey.c
++liblibrecrypto_la_SOURCES += idea/i_cbc.c
++liblibrecrypto_la_SOURCES += idea/i_cfb64.c
++liblibrecrypto_la_SOURCES += idea/i_ecb.c
++liblibrecrypto_la_SOURCES += idea/i_ofb64.c
++liblibrecrypto_la_SOURCES += idea/i_skey.c
+ noinst_HEADERS += idea/idea_lcl.h
+ 
+ # lhash
+-libcrypto_la_SOURCES += lhash/lh_stats.c
+-libcrypto_la_SOURCES += lhash/lhash.c
++liblibrecrypto_la_SOURCES += lhash/lh_stats.c
++liblibrecrypto_la_SOURCES += lhash/lhash.c
+ 
+ # md4
+-libcrypto_la_SOURCES += md4/md4_dgst.c
+-libcrypto_la_SOURCES += md4/md4_one.c
++liblibrecrypto_la_SOURCES += md4/md4_dgst.c
++liblibrecrypto_la_SOURCES += md4/md4_one.c
+ noinst_HEADERS += md4/md4_locl.h
+ 
+ # md5
+-libcrypto_la_SOURCES += md5/md5_dgst.c
+-libcrypto_la_SOURCES += md5/md5_one.c
++liblibrecrypto_la_SOURCES += md5/md5_dgst.c
++liblibrecrypto_la_SOURCES += md5/md5_one.c
+ noinst_HEADERS += md5/md5_locl.h
+ 
+ # modes
+-libcrypto_la_SOURCES += modes/cbc128.c
+-libcrypto_la_SOURCES += modes/ccm128.c
+-libcrypto_la_SOURCES += modes/cfb128.c
+-libcrypto_la_SOURCES += modes/ctr128.c
+-libcrypto_la_SOURCES += modes/cts128.c
+-libcrypto_la_SOURCES += modes/gcm128.c
+-libcrypto_la_SOURCES += modes/ofb128.c
+-libcrypto_la_SOURCES += modes/xts128.c
++liblibrecrypto_la_SOURCES += modes/cbc128.c
++liblibrecrypto_la_SOURCES += modes/ccm128.c
++liblibrecrypto_la_SOURCES += modes/cfb128.c
++liblibrecrypto_la_SOURCES += modes/ctr128.c
++liblibrecrypto_la_SOURCES += modes/cts128.c
++liblibrecrypto_la_SOURCES += modes/gcm128.c
++liblibrecrypto_la_SOURCES += modes/ofb128.c
++liblibrecrypto_la_SOURCES += modes/xts128.c
+ noinst_HEADERS += modes/modes_lcl.h
+ 
+ # objects
+-libcrypto_la_SOURCES += objects/o_names.c
+-libcrypto_la_SOURCES += objects/obj_dat.c
+-libcrypto_la_SOURCES += objects/obj_err.c
+-libcrypto_la_SOURCES += objects/obj_lib.c
+-libcrypto_la_SOURCES += objects/obj_xref.c
++liblibrecrypto_la_SOURCES += objects/o_names.c
++liblibrecrypto_la_SOURCES += objects/obj_dat.c
++liblibrecrypto_la_SOURCES += objects/obj_err.c
++liblibrecrypto_la_SOURCES += objects/obj_lib.c
++liblibrecrypto_la_SOURCES += objects/obj_xref.c
+ noinst_HEADERS += objects/obj_dat.h
+ noinst_HEADERS += objects/obj_xref.h
+ 
+ # ocsp
+-libcrypto_la_SOURCES += ocsp/ocsp_asn.c
+-libcrypto_la_SOURCES += ocsp/ocsp_cl.c
+-libcrypto_la_SOURCES += ocsp/ocsp_err.c
+-libcrypto_la_SOURCES += ocsp/ocsp_ext.c
+-libcrypto_la_SOURCES += ocsp/ocsp_ht.c
+-libcrypto_la_SOURCES += ocsp/ocsp_lib.c
+-libcrypto_la_SOURCES += ocsp/ocsp_prn.c
+-libcrypto_la_SOURCES += ocsp/ocsp_srv.c
+-libcrypto_la_SOURCES += ocsp/ocsp_vfy.c
++liblibrecrypto_la_SOURCES += ocsp/ocsp_asn.c
++liblibrecrypto_la_SOURCES += ocsp/ocsp_cl.c
++liblibrecrypto_la_SOURCES += ocsp/ocsp_err.c
++liblibrecrypto_la_SOURCES += ocsp/ocsp_ext.c
++liblibrecrypto_la_SOURCES += ocsp/ocsp_ht.c
++liblibrecrypto_la_SOURCES += ocsp/ocsp_lib.c
++liblibrecrypto_la_SOURCES += ocsp/ocsp_prn.c
++liblibrecrypto_la_SOURCES += ocsp/ocsp_srv.c
++liblibrecrypto_la_SOURCES += ocsp/ocsp_vfy.c
+ 
+ # pem
+-libcrypto_la_SOURCES += pem/pem_all.c
+-libcrypto_la_SOURCES += pem/pem_err.c
+-libcrypto_la_SOURCES += pem/pem_info.c
+-libcrypto_la_SOURCES += pem/pem_lib.c
+-libcrypto_la_SOURCES += pem/pem_oth.c
+-libcrypto_la_SOURCES += pem/pem_pk8.c
+-libcrypto_la_SOURCES += pem/pem_pkey.c
+-libcrypto_la_SOURCES += pem/pem_seal.c
+-libcrypto_la_SOURCES += pem/pem_sign.c
+-libcrypto_la_SOURCES += pem/pem_x509.c
+-libcrypto_la_SOURCES += pem/pem_xaux.c
+-libcrypto_la_SOURCES += pem/pvkfmt.c
++liblibrecrypto_la_SOURCES += pem/pem_all.c
++liblibrecrypto_la_SOURCES += pem/pem_err.c
++liblibrecrypto_la_SOURCES += pem/pem_info.c
++liblibrecrypto_la_SOURCES += pem/pem_lib.c
++liblibrecrypto_la_SOURCES += pem/pem_oth.c
++liblibrecrypto_la_SOURCES += pem/pem_pk8.c
++liblibrecrypto_la_SOURCES += pem/pem_pkey.c
++liblibrecrypto_la_SOURCES += pem/pem_seal.c
++liblibrecrypto_la_SOURCES += pem/pem_sign.c
++liblibrecrypto_la_SOURCES += pem/pem_x509.c
++liblibrecrypto_la_SOURCES += pem/pem_xaux.c
++liblibrecrypto_la_SOURCES += pem/pvkfmt.c
+ 
+ # pkcs12
+-libcrypto_la_SOURCES += pkcs12/p12_add.c
+-libcrypto_la_SOURCES += pkcs12/p12_asn.c
+-libcrypto_la_SOURCES += pkcs12/p12_attr.c
+-libcrypto_la_SOURCES += pkcs12/p12_crpt.c
+-libcrypto_la_SOURCES += pkcs12/p12_crt.c
+-libcrypto_la_SOURCES += pkcs12/p12_decr.c
+-libcrypto_la_SOURCES += pkcs12/p12_init.c
+-libcrypto_la_SOURCES += pkcs12/p12_key.c
+-libcrypto_la_SOURCES += pkcs12/p12_kiss.c
+-libcrypto_la_SOURCES += pkcs12/p12_mutl.c
+-libcrypto_la_SOURCES += pkcs12/p12_npas.c
+-libcrypto_la_SOURCES += pkcs12/p12_p8d.c
+-libcrypto_la_SOURCES += pkcs12/p12_p8e.c
+-libcrypto_la_SOURCES += pkcs12/p12_utl.c
+-libcrypto_la_SOURCES += pkcs12/pk12err.c
++liblibrecrypto_la_SOURCES += pkcs12/p12_add.c
++liblibrecrypto_la_SOURCES += pkcs12/p12_asn.c
++liblibrecrypto_la_SOURCES += pkcs12/p12_attr.c
++liblibrecrypto_la_SOURCES += pkcs12/p12_crpt.c
++liblibrecrypto_la_SOURCES += pkcs12/p12_crt.c
++liblibrecrypto_la_SOURCES += pkcs12/p12_decr.c
++liblibrecrypto_la_SOURCES += pkcs12/p12_init.c
++liblibrecrypto_la_SOURCES += pkcs12/p12_key.c
++liblibrecrypto_la_SOURCES += pkcs12/p12_kiss.c
++liblibrecrypto_la_SOURCES += pkcs12/p12_mutl.c
++liblibrecrypto_la_SOURCES += pkcs12/p12_npas.c
++liblibrecrypto_la_SOURCES += pkcs12/p12_p8d.c
++liblibrecrypto_la_SOURCES += pkcs12/p12_p8e.c
++liblibrecrypto_la_SOURCES += pkcs12/p12_utl.c
++liblibrecrypto_la_SOURCES += pkcs12/pk12err.c
+ 
+ # pkcs7
+-libcrypto_la_SOURCES += pkcs7/bio_pk7.c
+-libcrypto_la_SOURCES += pkcs7/pk7_asn1.c
+-libcrypto_la_SOURCES += pkcs7/pk7_attr.c
+-libcrypto_la_SOURCES += pkcs7/pk7_doit.c
+-libcrypto_la_SOURCES += pkcs7/pk7_lib.c
+-libcrypto_la_SOURCES += pkcs7/pk7_mime.c
+-libcrypto_la_SOURCES += pkcs7/pk7_smime.c
+-libcrypto_la_SOURCES += pkcs7/pkcs7err.c
++liblibrecrypto_la_SOURCES += pkcs7/bio_pk7.c
++liblibrecrypto_la_SOURCES += pkcs7/pk7_asn1.c
++liblibrecrypto_la_SOURCES += pkcs7/pk7_attr.c
++liblibrecrypto_la_SOURCES += pkcs7/pk7_doit.c
++liblibrecrypto_la_SOURCES += pkcs7/pk7_lib.c
++liblibrecrypto_la_SOURCES += pkcs7/pk7_mime.c
++liblibrecrypto_la_SOURCES += pkcs7/pk7_smime.c
++liblibrecrypto_la_SOURCES += pkcs7/pkcs7err.c
+ 
+ # poly1305
+-EXTRA_libcrypto_la_SOURCES += poly1305/poly1305-donna.c
+-libcrypto_la_SOURCES += poly1305/poly1305.c
++EXTRA_liblibrecrypto_la_SOURCES += poly1305/poly1305-donna.c
++liblibrecrypto_la_SOURCES += poly1305/poly1305.c
+ 
+ # rand
+-libcrypto_la_SOURCES += rand/rand_err.c
+-libcrypto_la_SOURCES += rand/rand_lib.c
+-libcrypto_la_SOURCES += rand/randfile.c
++liblibrecrypto_la_SOURCES += rand/rand_err.c
++liblibrecrypto_la_SOURCES += rand/rand_lib.c
++liblibrecrypto_la_SOURCES += rand/randfile.c
+ 
+ # rc2
+-libcrypto_la_SOURCES += rc2/rc2_cbc.c
+-libcrypto_la_SOURCES += rc2/rc2_ecb.c
+-libcrypto_la_SOURCES += rc2/rc2_skey.c
+-libcrypto_la_SOURCES += rc2/rc2cfb64.c
+-libcrypto_la_SOURCES += rc2/rc2ofb64.c
++liblibrecrypto_la_SOURCES += rc2/rc2_cbc.c
++liblibrecrypto_la_SOURCES += rc2/rc2_ecb.c
++liblibrecrypto_la_SOURCES += rc2/rc2_skey.c
++liblibrecrypto_la_SOURCES += rc2/rc2cfb64.c
++liblibrecrypto_la_SOURCES += rc2/rc2ofb64.c
+ noinst_HEADERS += rc2/rc2_locl.h
+ 
+ # rc4
+ noinst_HEADERS += rc4/rc4_locl.h
+ 
+ # ripemd
+-libcrypto_la_SOURCES += ripemd/rmd_dgst.c
+-libcrypto_la_SOURCES += ripemd/rmd_one.c
++liblibrecrypto_la_SOURCES += ripemd/rmd_dgst.c
++liblibrecrypto_la_SOURCES += ripemd/rmd_one.c
+ noinst_HEADERS += ripemd/rmd_locl.h
+ noinst_HEADERS += ripemd/rmdconst.h
+ 
+ # rsa
+-libcrypto_la_SOURCES += rsa/rsa_ameth.c
+-libcrypto_la_SOURCES += rsa/rsa_asn1.c
+-libcrypto_la_SOURCES += rsa/rsa_chk.c
+-libcrypto_la_SOURCES += rsa/rsa_crpt.c
+-libcrypto_la_SOURCES += rsa/rsa_depr.c
+-libcrypto_la_SOURCES += rsa/rsa_eay.c
+-libcrypto_la_SOURCES += rsa/rsa_err.c
+-libcrypto_la_SOURCES += rsa/rsa_gen.c
+-libcrypto_la_SOURCES += rsa/rsa_lib.c
+-libcrypto_la_SOURCES += rsa/rsa_meth.c
+-libcrypto_la_SOURCES += rsa/rsa_none.c
+-libcrypto_la_SOURCES += rsa/rsa_oaep.c
+-libcrypto_la_SOURCES += rsa/rsa_pk1.c
+-libcrypto_la_SOURCES += rsa/rsa_pmeth.c
+-libcrypto_la_SOURCES += rsa/rsa_prn.c
+-libcrypto_la_SOURCES += rsa/rsa_pss.c
+-libcrypto_la_SOURCES += rsa/rsa_saos.c
+-libcrypto_la_SOURCES += rsa/rsa_sign.c
+-libcrypto_la_SOURCES += rsa/rsa_x931.c
++liblibrecrypto_la_SOURCES += rsa/rsa_ameth.c
++liblibrecrypto_la_SOURCES += rsa/rsa_asn1.c
++liblibrecrypto_la_SOURCES += rsa/rsa_chk.c
++liblibrecrypto_la_SOURCES += rsa/rsa_crpt.c
++liblibrecrypto_la_SOURCES += rsa/rsa_depr.c
++liblibrecrypto_la_SOURCES += rsa/rsa_eay.c
++liblibrecrypto_la_SOURCES += rsa/rsa_err.c
++liblibrecrypto_la_SOURCES += rsa/rsa_gen.c
++liblibrecrypto_la_SOURCES += rsa/rsa_lib.c
++liblibrecrypto_la_SOURCES += rsa/rsa_meth.c
++liblibrecrypto_la_SOURCES += rsa/rsa_none.c
++liblibrecrypto_la_SOURCES += rsa/rsa_oaep.c
++liblibrecrypto_la_SOURCES += rsa/rsa_pk1.c
++liblibrecrypto_la_SOURCES += rsa/rsa_pmeth.c
++liblibrecrypto_la_SOURCES += rsa/rsa_prn.c
++liblibrecrypto_la_SOURCES += rsa/rsa_pss.c
++liblibrecrypto_la_SOURCES += rsa/rsa_saos.c
++liblibrecrypto_la_SOURCES += rsa/rsa_sign.c
++liblibrecrypto_la_SOURCES += rsa/rsa_x931.c
+ noinst_HEADERS += rsa/rsa_locl.h
+ 
+ # sha
+-libcrypto_la_SOURCES += sha/sha1_one.c
+-libcrypto_la_SOURCES += sha/sha1dgst.c
+-libcrypto_la_SOURCES += sha/sha256.c
+-libcrypto_la_SOURCES += sha/sha512.c
++liblibrecrypto_la_SOURCES += sha/sha1_one.c
++liblibrecrypto_la_SOURCES += sha/sha1dgst.c
++liblibrecrypto_la_SOURCES += sha/sha256.c
++liblibrecrypto_la_SOURCES += sha/sha512.c
+ noinst_HEADERS += sha/sha_locl.h
+ 
+ # stack
+-libcrypto_la_SOURCES += stack/stack.c
++liblibrecrypto_la_SOURCES += stack/stack.c
+ 
+ # ts
+-libcrypto_la_SOURCES += ts/ts_asn1.c
+-libcrypto_la_SOURCES += ts/ts_conf.c
+-libcrypto_la_SOURCES += ts/ts_err.c
+-libcrypto_la_SOURCES += ts/ts_lib.c
+-libcrypto_la_SOURCES += ts/ts_req_print.c
+-libcrypto_la_SOURCES += ts/ts_req_utils.c
+-libcrypto_la_SOURCES += ts/ts_rsp_print.c
+-libcrypto_la_SOURCES += ts/ts_rsp_sign.c
+-libcrypto_la_SOURCES += ts/ts_rsp_utils.c
+-libcrypto_la_SOURCES += ts/ts_rsp_verify.c
+-libcrypto_la_SOURCES += ts/ts_verify_ctx.c
++liblibrecrypto_la_SOURCES += ts/ts_asn1.c
++liblibrecrypto_la_SOURCES += ts/ts_conf.c
++liblibrecrypto_la_SOURCES += ts/ts_err.c
++liblibrecrypto_la_SOURCES += ts/ts_lib.c
++liblibrecrypto_la_SOURCES += ts/ts_req_print.c
++liblibrecrypto_la_SOURCES += ts/ts_req_utils.c
++liblibrecrypto_la_SOURCES += ts/ts_rsp_print.c
++liblibrecrypto_la_SOURCES += ts/ts_rsp_sign.c
++liblibrecrypto_la_SOURCES += ts/ts_rsp_utils.c
++liblibrecrypto_la_SOURCES += ts/ts_rsp_verify.c
++liblibrecrypto_la_SOURCES += ts/ts_verify_ctx.c
+ 
+ # txt_db
+-libcrypto_la_SOURCES += txt_db/txt_db.c
++liblibrecrypto_la_SOURCES += txt_db/txt_db.c
+ 
+ # ui
+-libcrypto_la_SOURCES += ui/ui_err.c
+-libcrypto_la_SOURCES += ui/ui_lib.c
++liblibrecrypto_la_SOURCES += ui/ui_err.c
++liblibrecrypto_la_SOURCES += ui/ui_lib.c
+ if !HOST_WIN
+-libcrypto_la_SOURCES += ui/ui_openssl.c
++liblibrecrypto_la_SOURCES += ui/ui_openssl.c
+ endif
+ if HOST_WIN
+-libcrypto_la_SOURCES += ui/ui_openssl_win.c
++liblibrecrypto_la_SOURCES += ui/ui_openssl_win.c
+ endif
+-libcrypto_la_SOURCES += ui/ui_util.c
++liblibrecrypto_la_SOURCES += ui/ui_util.c
+ noinst_HEADERS += ui/ui_locl.h
+ 
+ # whrlpool
+-libcrypto_la_SOURCES += whrlpool/wp_dgst.c
++liblibrecrypto_la_SOURCES += whrlpool/wp_dgst.c
+ noinst_HEADERS += whrlpool/wp_locl.h
+ 
+ # x509
+-libcrypto_la_SOURCES += x509/by_dir.c
+-libcrypto_la_SOURCES += x509/by_file.c
+-libcrypto_la_SOURCES += x509/by_mem.c
+-libcrypto_la_SOURCES += x509/x509_att.c
+-libcrypto_la_SOURCES += x509/x509_cmp.c
+-libcrypto_la_SOURCES += x509/x509_d2.c
+-libcrypto_la_SOURCES += x509/x509_def.c
+-libcrypto_la_SOURCES += x509/x509_err.c
+-libcrypto_la_SOURCES += x509/x509_ext.c
+-libcrypto_la_SOURCES += x509/x509_lu.c
+-libcrypto_la_SOURCES += x509/x509_obj.c
+-libcrypto_la_SOURCES += x509/x509_r2x.c
+-libcrypto_la_SOURCES += x509/x509_req.c
+-libcrypto_la_SOURCES += x509/x509_set.c
+-libcrypto_la_SOURCES += x509/x509_trs.c
+-libcrypto_la_SOURCES += x509/x509_txt.c
+-libcrypto_la_SOURCES += x509/x509_v3.c
+-libcrypto_la_SOURCES += x509/x509_vfy.c
+-libcrypto_la_SOURCES += x509/x509_vpm.c
+-libcrypto_la_SOURCES += x509/x509cset.c
+-libcrypto_la_SOURCES += x509/x509name.c
+-libcrypto_la_SOURCES += x509/x509rset.c
+-libcrypto_la_SOURCES += x509/x509spki.c
+-libcrypto_la_SOURCES += x509/x509type.c
+-libcrypto_la_SOURCES += x509/x_all.c
++liblibrecrypto_la_SOURCES += x509/by_dir.c
++liblibrecrypto_la_SOURCES += x509/by_file.c
++liblibrecrypto_la_SOURCES += x509/by_mem.c
++liblibrecrypto_la_SOURCES += x509/x509_att.c
++liblibrecrypto_la_SOURCES += x509/x509_cmp.c
++liblibrecrypto_la_SOURCES += x509/x509_d2.c
++liblibrecrypto_la_SOURCES += x509/x509_def.c
++liblibrecrypto_la_SOURCES += x509/x509_err.c
++liblibrecrypto_la_SOURCES += x509/x509_ext.c
++liblibrecrypto_la_SOURCES += x509/x509_lu.c
++liblibrecrypto_la_SOURCES += x509/x509_obj.c
++liblibrecrypto_la_SOURCES += x509/x509_r2x.c
++liblibrecrypto_la_SOURCES += x509/x509_req.c
++liblibrecrypto_la_SOURCES += x509/x509_set.c
++liblibrecrypto_la_SOURCES += x509/x509_trs.c
++liblibrecrypto_la_SOURCES += x509/x509_txt.c
++liblibrecrypto_la_SOURCES += x509/x509_v3.c
++liblibrecrypto_la_SOURCES += x509/x509_vfy.c
++liblibrecrypto_la_SOURCES += x509/x509_vpm.c
++liblibrecrypto_la_SOURCES += x509/x509cset.c
++liblibrecrypto_la_SOURCES += x509/x509name.c
++liblibrecrypto_la_SOURCES += x509/x509rset.c
++liblibrecrypto_la_SOURCES += x509/x509spki.c
++liblibrecrypto_la_SOURCES += x509/x509type.c
++liblibrecrypto_la_SOURCES += x509/x_all.c
+ noinst_HEADERS += x509/x509_lcl.h
+ noinst_HEADERS += x509/vpm_int.h
+ 
+ # x509v3
+-libcrypto_la_SOURCES += x509v3/pcy_cache.c
+-libcrypto_la_SOURCES += x509v3/pcy_data.c
+-libcrypto_la_SOURCES += x509v3/pcy_lib.c
+-libcrypto_la_SOURCES += x509v3/pcy_map.c
+-libcrypto_la_SOURCES += x509v3/pcy_node.c
+-libcrypto_la_SOURCES += x509v3/pcy_tree.c
+-libcrypto_la_SOURCES += x509v3/v3_akey.c
+-libcrypto_la_SOURCES += x509v3/v3_akeya.c
+-libcrypto_la_SOURCES += x509v3/v3_alt.c
+-libcrypto_la_SOURCES += x509v3/v3_bcons.c
+-libcrypto_la_SOURCES += x509v3/v3_bitst.c
+-libcrypto_la_SOURCES += x509v3/v3_conf.c
+-libcrypto_la_SOURCES += x509v3/v3_cpols.c
+-libcrypto_la_SOURCES += x509v3/v3_crld.c
+-libcrypto_la_SOURCES += x509v3/v3_enum.c
+-libcrypto_la_SOURCES += x509v3/v3_extku.c
+-libcrypto_la_SOURCES += x509v3/v3_genn.c
+-libcrypto_la_SOURCES += x509v3/v3_ia5.c
+-libcrypto_la_SOURCES += x509v3/v3_info.c
+-libcrypto_la_SOURCES += x509v3/v3_int.c
+-libcrypto_la_SOURCES += x509v3/v3_lib.c
+-libcrypto_la_SOURCES += x509v3/v3_ncons.c
+-libcrypto_la_SOURCES += x509v3/v3_ocsp.c
+-libcrypto_la_SOURCES += x509v3/v3_pci.c
+-libcrypto_la_SOURCES += x509v3/v3_pcia.c
+-libcrypto_la_SOURCES += x509v3/v3_pcons.c
+-libcrypto_la_SOURCES += x509v3/v3_pku.c
+-libcrypto_la_SOURCES += x509v3/v3_pmaps.c
+-libcrypto_la_SOURCES += x509v3/v3_prn.c
+-libcrypto_la_SOURCES += x509v3/v3_purp.c
+-libcrypto_la_SOURCES += x509v3/v3_skey.c
+-libcrypto_la_SOURCES += x509v3/v3_sxnet.c
+-libcrypto_la_SOURCES += x509v3/v3_utl.c
+-libcrypto_la_SOURCES += x509v3/v3err.c
++liblibrecrypto_la_SOURCES += x509v3/pcy_cache.c
++liblibrecrypto_la_SOURCES += x509v3/pcy_data.c
++liblibrecrypto_la_SOURCES += x509v3/pcy_lib.c
++liblibrecrypto_la_SOURCES += x509v3/pcy_map.c
++liblibrecrypto_la_SOURCES += x509v3/pcy_node.c
++liblibrecrypto_la_SOURCES += x509v3/pcy_tree.c
++liblibrecrypto_la_SOURCES += x509v3/v3_akey.c
++liblibrecrypto_la_SOURCES += x509v3/v3_akeya.c
++liblibrecrypto_la_SOURCES += x509v3/v3_alt.c
++liblibrecrypto_la_SOURCES += x509v3/v3_bcons.c
++liblibrecrypto_la_SOURCES += x509v3/v3_bitst.c
++liblibrecrypto_la_SOURCES += x509v3/v3_conf.c
++liblibrecrypto_la_SOURCES += x509v3/v3_cpols.c
++liblibrecrypto_la_SOURCES += x509v3/v3_crld.c
++liblibrecrypto_la_SOURCES += x509v3/v3_enum.c
++liblibrecrypto_la_SOURCES += x509v3/v3_extku.c
++liblibrecrypto_la_SOURCES += x509v3/v3_genn.c
++liblibrecrypto_la_SOURCES += x509v3/v3_ia5.c
++liblibrecrypto_la_SOURCES += x509v3/v3_info.c
++liblibrecrypto_la_SOURCES += x509v3/v3_int.c
++liblibrecrypto_la_SOURCES += x509v3/v3_lib.c
++liblibrecrypto_la_SOURCES += x509v3/v3_ncons.c
++liblibrecrypto_la_SOURCES += x509v3/v3_ocsp.c
++liblibrecrypto_la_SOURCES += x509v3/v3_pci.c
++liblibrecrypto_la_SOURCES += x509v3/v3_pcia.c
++liblibrecrypto_la_SOURCES += x509v3/v3_pcons.c
++liblibrecrypto_la_SOURCES += x509v3/v3_pku.c
++liblibrecrypto_la_SOURCES += x509v3/v3_pmaps.c
++liblibrecrypto_la_SOURCES += x509v3/v3_prn.c
++liblibrecrypto_la_SOURCES += x509v3/v3_purp.c
++liblibrecrypto_la_SOURCES += x509v3/v3_skey.c
++liblibrecrypto_la_SOURCES += x509v3/v3_sxnet.c
++liblibrecrypto_la_SOURCES += x509v3/v3_utl.c
++liblibrecrypto_la_SOURCES += x509v3/v3err.c
+ noinst_HEADERS += x509v3/ext_dat.h
+ noinst_HEADERS += x509v3/pcy_int.h
+diff --git a/crypto/Makefile.am.elf-x86_64 b/crypto/Makefile.am.elf-x86_64
+index 4cd34e2..1d7e022 100644
+--- a/crypto/Makefile.am.elf-x86_64
++++ b/crypto/Makefile.am.elf-x86_64
+@@ -22,20 +22,20 @@ ASM_X86_64_ELF += cpuid-elf-x86_64.S
+ EXTRA_DIST += $(ASM_X86_64_ELF)
+ 
+ if HOST_ASM_ELF_X86_64
+-libcrypto_la_CPPFLAGS += -DAES_ASM
+-libcrypto_la_CPPFLAGS += -DBSAES_ASM
+-libcrypto_la_CPPFLAGS += -DVPAES_ASM
+-libcrypto_la_CPPFLAGS += -DOPENSSL_IA32_SSE2
+-libcrypto_la_CPPFLAGS += -DOPENSSL_BN_ASM_MONT
+-libcrypto_la_CPPFLAGS += -DOPENSSL_BN_ASM_MONT5
+-libcrypto_la_CPPFLAGS += -DOPENSSL_BN_ASM_GF2m
+-libcrypto_la_CPPFLAGS += -DMD5_ASM
+-libcrypto_la_CPPFLAGS += -DGHASH_ASM
+-libcrypto_la_CPPFLAGS += -DRSA_ASM
+-libcrypto_la_CPPFLAGS += -DSHA1_ASM
+-libcrypto_la_CPPFLAGS += -DSHA256_ASM
+-libcrypto_la_CPPFLAGS += -DSHA512_ASM
+-libcrypto_la_CPPFLAGS += -DWHIRLPOOL_ASM
+-libcrypto_la_CPPFLAGS += -DOPENSSL_CPUID_OBJ
+-libcrypto_la_SOURCES += $(ASM_X86_64_ELF)
++liblibrecrypto_la_CPPFLAGS += -DAES_ASM
++liblibrecrypto_la_CPPFLAGS += -DBSAES_ASM
++liblibrecrypto_la_CPPFLAGS += -DVPAES_ASM
++liblibrecrypto_la_CPPFLAGS += -DOPENSSL_IA32_SSE2
++liblibrecrypto_la_CPPFLAGS += -DOPENSSL_BN_ASM_MONT
++liblibrecrypto_la_CPPFLAGS += -DOPENSSL_BN_ASM_MONT5
++liblibrecrypto_la_CPPFLAGS += -DOPENSSL_BN_ASM_GF2m
++liblibrecrypto_la_CPPFLAGS += -DMD5_ASM
++liblibrecrypto_la_CPPFLAGS += -DGHASH_ASM
++liblibrecrypto_la_CPPFLAGS += -DRSA_ASM
++liblibrecrypto_la_CPPFLAGS += -DSHA1_ASM
++liblibrecrypto_la_CPPFLAGS += -DSHA256_ASM
++liblibrecrypto_la_CPPFLAGS += -DSHA512_ASM
++liblibrecrypto_la_CPPFLAGS += -DWHIRLPOOL_ASM
++liblibrecrypto_la_CPPFLAGS += -DOPENSSL_CPUID_OBJ
++liblibrecrypto_la_SOURCES += $(ASM_X86_64_ELF)
+ endif
+diff --git a/crypto/Makefile.am.macosx-x86_64 b/crypto/Makefile.am.macosx-x86_64
+index 2118156..129a58a 100644
+--- a/crypto/Makefile.am.macosx-x86_64
++++ b/crypto/Makefile.am.macosx-x86_64
+@@ -22,20 +22,20 @@ ASM_X86_64_MACOSX += cpuid-macosx-x86_64.S
+ EXTRA_DIST += $(ASM_X86_64_MACOSX)
+ 
+ if HOST_ASM_MACOSX_X86_64
+-libcrypto_la_CPPFLAGS += -DAES_ASM
+-libcrypto_la_CPPFLAGS += -DBSAES_ASM
+-libcrypto_la_CPPFLAGS += -DVPAES_ASM
+-libcrypto_la_CPPFLAGS += -DOPENSSL_IA32_SSE2
+-libcrypto_la_CPPFLAGS += -DOPENSSL_BN_ASM_MONT
+-libcrypto_la_CPPFLAGS += -DOPENSSL_BN_ASM_MONT5
+-libcrypto_la_CPPFLAGS += -DOPENSSL_BN_ASM_GF2m
+-libcrypto_la_CPPFLAGS += -DMD5_ASM
+-libcrypto_la_CPPFLAGS += -DGHASH_ASM
+-libcrypto_la_CPPFLAGS += -DRSA_ASM
+-libcrypto_la_CPPFLAGS += -DSHA1_ASM
+-libcrypto_la_CPPFLAGS += -DSHA256_ASM
+-libcrypto_la_CPPFLAGS += -DSHA512_ASM
+-libcrypto_la_CPPFLAGS += -DWHIRLPOOL_ASM
+-libcrypto_la_CPPFLAGS += -DOPENSSL_CPUID_OBJ
+-libcrypto_la_SOURCES += $(ASM_X86_64_MACOSX)
++liblibrecrypto_la_CPPFLAGS += -DAES_ASM
++liblibrecrypto_la_CPPFLAGS += -DBSAES_ASM
++liblibrecrypto_la_CPPFLAGS += -DVPAES_ASM
++liblibrecrypto_la_CPPFLAGS += -DOPENSSL_IA32_SSE2
++liblibrecrypto_la_CPPFLAGS += -DOPENSSL_BN_ASM_MONT
++liblibrecrypto_la_CPPFLAGS += -DOPENSSL_BN_ASM_MONT5
++liblibrecrypto_la_CPPFLAGS += -DOPENSSL_BN_ASM_GF2m
++liblibrecrypto_la_CPPFLAGS += -DMD5_ASM
++liblibrecrypto_la_CPPFLAGS += -DGHASH_ASM
++liblibrecrypto_la_CPPFLAGS += -DRSA_ASM
++liblibrecrypto_la_CPPFLAGS += -DSHA1_ASM
++liblibrecrypto_la_CPPFLAGS += -DSHA256_ASM
++liblibrecrypto_la_CPPFLAGS += -DSHA512_ASM
++liblibrecrypto_la_CPPFLAGS += -DWHIRLPOOL_ASM
++liblibrecrypto_la_CPPFLAGS += -DOPENSSL_CPUID_OBJ
++liblibrecrypto_la_SOURCES += $(ASM_X86_64_MACOSX)
+ endif
+diff --git a/libcrypto.pc.in b/libcrypto.pc.in
+index 1823326..ee41744 100644
+--- a/libcrypto.pc.in
++++ b/libcrypto.pc.in
+@@ -1,15 +1,15 @@
+ #libcrypto pkg-config source file
+ 
+-prefix=@prefix@
++prefix=@prefix
+ exec_prefix=@exec_prefix@
+ libdir=@libdir@
+-includedir=@includedir@
++includedir=@includedir@/libressl
+ 
+ Name: LibreSSL-libcrypto
+ Description: LibreSSL cryptography library
+ Version: @VERSION@
+ Requires:
+ Conflicts:
+-Libs: -L${libdir} -lcrypto
++Libs: -L${libdir} -llibrecrypto
+ Libs.private: @LIBS@ @PLATFORM_LDADD@
+ Cflags: -I${includedir}
+diff --git a/libssl.pc.in b/libssl.pc.in
+index ae61aec..0535d2c 100644
+--- a/libssl.pc.in
++++ b/libssl.pc.in
+@@ -3,14 +3,14 @@
+ prefix=@prefix@
+ exec_prefix=@exec_prefix@
+ libdir=@libdir@
+-includedir=@includedir@
++includedir=@includedir@/libressl
+ 
+ Name: LibreSSL-libssl
+ Description: Secure Sockets Layer and cryptography libraries
+ Version: @VERSION@
+ Requires:
+-Requires.private: libcrypto
++Requires.private: liblibrecrypto
+ Conflicts:
+-Libs: -L${libdir} -lssl
+-Libs.private: @LIBS@ -lcrypto @PLATFORM_LDADD@
++Libs: -L${libdir} -llibressl
++Libs.private: @LIBS@ -llibrecrypto @PLATFORM_LDADD@
+ Cflags: -I${includedir}
+diff --git a/libtls.pc.in b/libtls.pc.in
+index 82a6a71..96da3a4 100644
+--- a/libtls.pc.in
++++ b/libtls.pc.in
+@@ -3,14 +3,14 @@
+ prefix=@prefix@
+ exec_prefix=@exec_prefix@
+ libdir=@libdir@
+-includedir=@includedir@
++includedir=@includedir@/libressl
+ 
+ Name: LibreSSL-libtls
+ Description: Secure communications using the TLS socket protocol.
+ Version: @VERSION@
+ Requires:
+-Requires.private: libcrypto libssl
++Requires.private: liblibrecrypto liblibressl
+ Conflicts:
+ Libs: -L${libdir} -ltls
+-Libs.private: @LIBS@ -lcrypto -lssl @PLATFORM_LDADD@
++Libs.private: @LIBS@ -llibrecrypto -llibressl @PLATFORM_LDADD@
+ Cflags: -I${includedir}
+diff --git a/openssl.pc.in b/openssl.pc.in
+index b4acfa5..76f5d85 100644
+--- a/openssl.pc.in
++++ b/openssl.pc.in
+@@ -3,9 +3,9 @@
+ prefix=@prefix@
+ exec_prefix=@exec_prefix@
+ libdir=@libdir@
+-includedir=@includedir@
++includedir=@includedir@/libressl
+ 
+ Name: LibreSSL
+ Description: Secure Sockets Layer and cryptography libraries and tools
+ Version: @VERSION@
+-Requires: libssl libcrypto
++Requires: liblibressl liblibrecrypto
+diff --git a/ssl/Makefile.am b/ssl/Makefile.am
+index 3c348d3..aaddbf6 100644
+--- a/ssl/Makefile.am
++++ b/ssl/Makefile.am
+@@ -1,53 +1,53 @@
+ include $(top_srcdir)/Makefile.am.common
+ 
+-lib_LTLIBRARIES = libssl.la
++lib_LTLIBRARIES = liblibressl.la
+ 
+ EXTRA_DIST = VERSION
+ EXTRA_DIST += CMakeLists.txt
+ EXTRA_DIST += ssl.sym
+ 
+-libssl_la_LDFLAGS = -version-info @LIBSSL_VERSION@ -no-undefined -export-symbols $(top_srcdir)/ssl/ssl.sym
+-libssl_la_LIBADD = $(abs_top_builddir)/crypto/libcrypto.la
++liblibressl_la_LDFLAGS = -version-info @LIBSSL_VERSION@ -no-undefined -export-symbols $(top_srcdir)/ssl/ssl.sym
++liblibressl_la_LIBADD = $(abs_top_builddir)/crypto/liblibrecrypto.la
+ 
+-libssl_la_SOURCES = bio_ssl.c
+-libssl_la_SOURCES += bs_ber.c
+-libssl_la_SOURCES += bs_cbb.c
+-libssl_la_SOURCES += bs_cbs.c
+-libssl_la_SOURCES += d1_both.c
+-libssl_la_SOURCES += d1_clnt.c
+-libssl_la_SOURCES += d1_enc.c
+-libssl_la_SOURCES += d1_lib.c
+-libssl_la_SOURCES += d1_meth.c
+-libssl_la_SOURCES += d1_pkt.c
+-libssl_la_SOURCES += d1_srtp.c
+-libssl_la_SOURCES += d1_srvr.c
+-libssl_la_SOURCES += pqueue.c
+-libssl_la_SOURCES += s3_cbc.c
+-libssl_la_SOURCES += s3_lib.c
+-libssl_la_SOURCES += ssl_algs.c
+-libssl_la_SOURCES += ssl_asn1.c
+-libssl_la_SOURCES += ssl_both.c
+-libssl_la_SOURCES += ssl_cert.c
+-libssl_la_SOURCES += ssl_ciph.c
+-libssl_la_SOURCES += ssl_clnt.c
+-libssl_la_SOURCES += ssl_err.c
+-libssl_la_SOURCES += ssl_init.c
+-libssl_la_SOURCES += ssl_lib.c
+-libssl_la_SOURCES += ssl_packet.c
+-libssl_la_SOURCES += ssl_pkt.c
+-libssl_la_SOURCES += ssl_rsa.c
+-libssl_la_SOURCES += ssl_sess.c
+-libssl_la_SOURCES += ssl_srvr.c
+-libssl_la_SOURCES += ssl_stat.c
+-libssl_la_SOURCES += ssl_tlsext.c
+-libssl_la_SOURCES += ssl_txt.c
+-libssl_la_SOURCES += ssl_versions.c
+-libssl_la_SOURCES += t1_clnt.c
+-libssl_la_SOURCES += t1_enc.c
+-libssl_la_SOURCES += t1_hash.c
+-libssl_la_SOURCES += t1_lib.c
+-libssl_la_SOURCES += t1_meth.c
+-libssl_la_SOURCES += t1_srvr.c
++liblibressl_la_SOURCES = bio_ssl.c
++liblibressl_la_SOURCES += bs_ber.c
++liblibressl_la_SOURCES += bs_cbb.c
++liblibressl_la_SOURCES += bs_cbs.c
++liblibressl_la_SOURCES += d1_both.c
++liblibressl_la_SOURCES += d1_clnt.c
++liblibressl_la_SOURCES += d1_enc.c
++liblibressl_la_SOURCES += d1_lib.c
++liblibressl_la_SOURCES += d1_meth.c
++liblibressl_la_SOURCES += d1_pkt.c
++liblibressl_la_SOURCES += d1_srtp.c
++liblibressl_la_SOURCES += d1_srvr.c
++liblibressl_la_SOURCES += pqueue.c
++liblibressl_la_SOURCES += s3_cbc.c
++liblibressl_la_SOURCES += s3_lib.c
++liblibressl_la_SOURCES += ssl_algs.c
++liblibressl_la_SOURCES += ssl_asn1.c
++liblibressl_la_SOURCES += ssl_both.c
++liblibressl_la_SOURCES += ssl_cert.c
++liblibressl_la_SOURCES += ssl_ciph.c
++liblibressl_la_SOURCES += ssl_clnt.c
++liblibressl_la_SOURCES += ssl_err.c
++liblibressl_la_SOURCES += ssl_init.c
++liblibressl_la_SOURCES += ssl_lib.c
++liblibressl_la_SOURCES += ssl_packet.c
++liblibressl_la_SOURCES += ssl_pkt.c
++liblibressl_la_SOURCES += ssl_rsa.c
++liblibressl_la_SOURCES += ssl_sess.c
++liblibressl_la_SOURCES += ssl_srvr.c
++liblibressl_la_SOURCES += ssl_stat.c
++liblibressl_la_SOURCES += ssl_tlsext.c
++liblibressl_la_SOURCES += ssl_txt.c
++liblibressl_la_SOURCES += ssl_versions.c
++liblibressl_la_SOURCES += t1_clnt.c
++liblibressl_la_SOURCES += t1_enc.c
++liblibressl_la_SOURCES += t1_hash.c
++liblibressl_la_SOURCES += t1_lib.c
++liblibressl_la_SOURCES += t1_meth.c
++liblibressl_la_SOURCES += t1_srvr.c
+ 
+ noinst_HEADERS = srtp.h
+ noinst_HEADERS += ssl_locl.h
+diff --git a/tests/Makefile.am b/tests/Makefile.am
+index 624e597..6cbbd72 100644
+--- a/tests/Makefile.am
++++ b/tests/Makefile.am
+@@ -7,12 +7,12 @@ AM_CPPFLAGS += -I $(top_srcdir)/apps/openssl
+ AM_CPPFLAGS += -I $(top_srcdir)/apps/openssl/compat
+ AM_CPPFLAGS += -D_PATH_SSL_CA_FILE=\"$(top_srcdir)/apps/openssl/cert.pem\"
+ 
+-LDADD = $(abs_top_builddir)/tls/.libs/libtls.a
+-LDADD += $(abs_top_builddir)/ssl/.libs/libssl.a
+-LDADD += $(abs_top_builddir)/crypto/.libs/libcrypto.a
++LDADD = $(abs_top_builddir)/tls/.libs/liblibretls.a
++LDADD += $(abs_top_builddir)/ssl/.libs/liblibressl.a
++LDADD += $(abs_top_builddir)/crypto/.libs/liblibrecrypto.a
+ LDADD += $(PLATFORM_LDADD) $(PROG_LDADD)
+ if HOST_ASM_MACOSX_X86_64
+-LDADD += $(abs_top_builddir)/crypto/.libs/libcrypto_la-cpuid-macosx-x86_64.o
++LDADD += $(abs_top_builddir)/crypto/.libs/libliblibrecrypto_la-cpuid-macosx-x86_64.o
+ endif
+ 
+ TEST_LOG_DRIVER = env AM_TAP_AWK='$(AWK)' $(SHELL) $(top_srcdir)/tap-driver.sh
+diff --git a/tls/Makefile.am b/tls/Makefile.am
+index bd2707a..c1203cb 100644
+--- a/tls/Makefile.am
++++ b/tls/Makefile.am
+@@ -1,39 +1,39 @@
+ include $(top_srcdir)/Makefile.am.common
+ 
+-lib_LTLIBRARIES = libtls.la
++lib_LTLIBRARIES = liblibretls.la
+ 
+ EXTRA_DIST = VERSION
+ EXTRA_DIST += CMakeLists.txt
+ EXTRA_DIST += tls.sym
+ 
+-libtls_la_LDFLAGS = -version-info @LIBTLS_VERSION@ -no-undefined -export-symbols $(top_srcdir)/tls/tls.sym
+-libtls_la_LIBADD = $(abs_top_builddir)/ssl/libssl.la
+-libtls_la_LIBADD += $(abs_top_builddir)/crypto/libcrypto.la
+-libtls_la_LIBADD += $(PLATFORM_LDADD)
++liblibretls_la_LDFLAGS = -version-info @LIBTLS_VERSION@ -no-undefined -export-symbols $(top_srcdir)/tls/tls.sym
++liblibretls_la_LIBADD = $(abs_top_builddir)/ssl/liblibressl.la
++liblibretls_la_LIBADD += $(abs_top_builddir)/crypto/liblibrecrypto.la
++liblibretls_la_LIBADD += $(PLATFORM_LDADD)
+ 
+-libtls_la_CPPFLAGS = $(AM_CPPFLAGS)
++liblibretls_la_CPPFLAGS = $(AM_CPPFLAGS)
+ if OPENSSLDIR_DEFINED
+-libtls_la_CPPFLAGS += -D_PATH_SSL_CA_FILE=\"@OPENSSLDIR@/cert.pem\"
++liblibretls_la_CPPFLAGS += -D_PATH_SSL_CA_FILE=\"@OPENSSLDIR@/cert.pem\"
+ else
+-libtls_la_CPPFLAGS += -D_PATH_SSL_CA_FILE=\"$(sysconfdir)/ssl/cert.pem\"
++liblibretls_la_CPPFLAGS += -D_PATH_SSL_CA_FILE=\"$(sysconfdir)/ssl/cert.pem\"
+ endif
+ 
+-libtls_la_SOURCES = tls.c
+-libtls_la_SOURCES += tls_client.c
+-libtls_la_SOURCES += tls_bio_cb.c
+-libtls_la_SOURCES += tls_config.c
+-libtls_la_SOURCES += tls_conninfo.c
+-libtls_la_SOURCES += tls_keypair.c
+-libtls_la_SOURCES += tls_server.c
+-libtls_la_SOURCES += tls_ocsp.c
+-libtls_la_SOURCES += tls_peer.c
+-libtls_la_SOURCES += tls_util.c
+-libtls_la_SOURCES += tls_verify.c
++liblibretls_la_SOURCES = tls.c
++liblibretls_la_SOURCES += tls_client.c
++liblibretls_la_SOURCES += tls_bio_cb.c
++liblibretls_la_SOURCES += tls_config.c
++liblibretls_la_SOURCES += tls_conninfo.c
++liblibretls_la_SOURCES += tls_keypair.c
++liblibretls_la_SOURCES += tls_server.c
++liblibretls_la_SOURCES += tls_ocsp.c
++liblibretls_la_SOURCES += tls_peer.c
++liblibretls_la_SOURCES += tls_util.c
++liblibretls_la_SOURCES += tls_verify.c
+ noinst_HEADERS = tls_internal.h
+ 
+ if HOST_WIN
+-libtls_la_SOURCES += compat/ftruncate.c
+-libtls_la_SOURCES += compat/getuid.c
+-libtls_la_SOURCES += compat/pread.c
+-libtls_la_SOURCES += compat/pwrite.c
++liblibretls_la_SOURCES += compat/ftruncate.c
++liblibretls_la_SOURCES += compat/getuid.c
++liblibretls_la_SOURCES += compat/pread.c
++liblibretls_la_SOURCES += compat/pwrite.c
+ endif

--- a/patches/libressl-from-Alexpux/0002-libressl_relocation-tests.patch
+++ b/patches/libressl-from-Alexpux/0002-libressl_relocation-tests.patch
@@ -1,0 +1,101 @@
+ tests/ssltest.sh                 |   10 +-
+ tests/testdsa.sh                 |   10 +-
+ tests/testenc.sh                 |   10 +-
+ tests/testrsa.sh                 |   10 +-
+
+diff --git a/tests/ssltest.sh b/tests/ssltest.sh
+index 28da3ac..72dadc1 100755
+--- a/tests/ssltest.sh
++++ b/tests/ssltest.sh
+@@ -7,14 +7,14 @@ if [ -e ./ssltest.exe ]; then
+ fi
+ 
+ if [ -d ../apps/openssl ]; then
+-	openssl_bin=../apps/openssl/openssl
+-	if [ -e ../apps/openssl/openssl.exe ]; then
+-		openssl_bin=../apps/openssl/openssl.exe
++	openssl_bin=../apps/openssl/libressl
++	if [ -e ../apps/openssl/libressl.exe ]; then
++		openssl_bin=../apps/openssl/libressl.exe
+ 	fi
+ else
+ 	openssl_bin=../apps/openssl
+-	if [ -e ../apps/openssl.exe ]; then
+-		openssl_bin=../apps/openssl.exe
++	if [ -e ../apps/libressl.exe ]; then
++		openssl_bin=../apps/libressl.exe
+ 	fi
+ fi
+ 
+diff --git a/tests/testdsa.sh b/tests/testdsa.sh
+index 7ecb8ef..307fa07 100755
+--- a/tests/testdsa.sh
++++ b/tests/testdsa.sh
+@@ -5,14 +5,14 @@
+ #Test DSA certificate generation of openssl
+ 
+ if [ -d ../apps/openssl ]; then
+-	cmd=../apps/openssl/openssl
+-	if [ -e ../apps/openssl/openssl.exe ]; then
+-		cmd=../apps/openssl/openssl.exe
++	cmd=../apps/openssl/libressl
++	if [ -e ../apps/openssl/libressl.exe ]; then
++		cmd=../apps/openssl/libressl.exe
+ 	fi
+ else
+ 	cmd=../apps/openssl
+-	if [ -e ../apps/openssl.exe ]; then
+-		cmd=../apps/openssl.exe
++	if [ -e ../apps/libressl.exe ]; then
++		cmd=../apps/libressl.exe
+ 	fi
+ fi
+ 
+diff --git a/tests/testenc.sh b/tests/testenc.sh
+index 63bce34..f7e8229 100755
+--- a/tests/testenc.sh
++++ b/tests/testenc.sh
+@@ -3,14 +3,14 @@
+ 
+ test=p
+ if [ -d ../apps/openssl ]; then
+-	cmd=../apps/openssl/openssl
+-	if [ -e ../apps/openssl/openssl.exe ]; then
+-		cmd=../apps/openssl/openssl.exe
++	cmd=../apps/openssl/libressl
++	if [ -e ../apps/openssl/libressl.exe ]; then
++		cmd=../apps/openssl/libressl.exe
+ 	fi
+ else
+ 	cmd=../apps/openssl
+-	if [ -e ../apps/openssl.exe ]; then
+-		cmd=../apps/openssl.exe
++	if [ -e ../apps/libressl.exe ]; then
++		cmd=../apps/libressl.exe
+ 	fi
+ fi
+ 
+diff --git a/tests/testrsa.sh b/tests/testrsa.sh
+index e644999..8e5f005 100755
+--- a/tests/testrsa.sh
++++ b/tests/testrsa.sh
+@@ -5,14 +5,14 @@
+ #Test RSA certificate generation of openssl
+ 
+ if [ -d ../apps/openssl ]; then
+-	cmd=../apps/openssl/openssl
+-	if [ -e ../apps/openssl/openssl.exe ]; then
+-		cmd=../apps/openssl/openssl.exe
++	cmd=../apps/openssl/libressl
++	if [ -e ../apps/openssl/libressl.exe ]; then
++		cmd=../apps/openssl/libressl.exe
+ 	fi
+ else
+ 	cmd=../apps/openssl
+-	if [ -e ../apps/openssl.exe ]; then
+-		cmd=../apps/openssl.exe
++	if [ -e ../apps/libressl.exe ]; then
++		cmd=../apps/libressl.exe
+ 	fi
+ fi
+ 

--- a/patches/libressl-from-Alexpux/PKGBUILD.txt
+++ b/patches/libressl-from-Alexpux/PKGBUILD.txt
@@ -1,0 +1,87 @@
+# Maintainer: Ilya Rakhlin <i.rakhlin@gmail.com>
+
+_realname=libressl
+pkgbase=mingw-w64-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgver=2.8.2
+pkgrel=1
+pkgdesc="LibreSSL Encryption (mingw-w64)"
+arch=('any')
+url='https://www.libressl.org/'
+license=('BSD')
+options=('staticlibs' 'strip')
+depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs")
+makedepends=("${MINGW_PACKAGE_PREFIX}-gcc")
+source=("https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/${_realname}-${pkgver}.tar.gz"
+        "0001-libressl_relocation-msys.patch"
+        "0002-libressl_relocation-tests.patch")
+sha256sums=('b8cb31e59f1294557bfc80f2a662969bc064e83006ceef0574e2553a1c254fd5'
+            'fe8ec69671922862c0d57dae902c8fe4d07a6d599a694ec903e58396fa964bb1'
+            '06500c7f09c2067b17e00d9fa4feb6aec922b8525f710a0dea43bd873a5f447b')
+
+prepare() {
+  cd ${srcdir}/${_realname}-${pkgver}
+  patch -p1 -i ${srcdir}/0001-libressl_relocation-msys.patch
+  patch -p1 -i ${srcdir}/0002-libressl_relocation-tests.patch
+  mv libtls.pc.in liblibretls.pc.in
+  mv libcrypto.pc.in liblibrecrypto.pc.in
+  mv libssl.pc.in liblibressl.pc.in
+  mv openssl.pc.in libressl.pc.in
+  mv apps/openssl/openssl.c apps/openssl/libressl.c
+  autoreconf -fiv
+}
+
+build() {
+  cd "${srcdir}"/${_realname}-${pkgver}
+  [[ -d "${srcdir}"/build-${CARCH}-shared ]] && rm -rf "${srcdir}"/build-${CARCH}-shared
+  [[ -d "${srcdir}"/build-${CARCH}-static ]] && rm -rf "${srcdir}"/build-${CARCH}-static
+  mkdir -p "${srcdir}"/build-${MINGW_CHOST}-shared "${srcdir}"/build-${MINGW_CHOST}-static
+
+  msg "Building static lib..."
+  (cd "${srcdir}"/build-${MINGW_CHOST}-static
+  ../${_realname}-${pkgver}/configure \
+    --prefix=${MINGW_PREFIX} \
+    --build=${MINGW_CHOST} \
+    --host=${MINGW_CHOST} \
+    --target=${MINGW_CHOST} \
+    --enable-static \
+    --disable-shared \
+    --with-openssldir=${MINGW_PREFIX}/share/libressl
+  make
+  )
+
+  msg "Building shared library..."
+  (cd "${srcdir}"/build-${MINGW_CHOST}-shared
+  ../${_realname}-${pkgver}/configure \
+    --prefix=${MINGW_PREFIX} \
+    --build=${MINGW_CHOST} \
+    --host=${MINGW_CHOST} \
+    --target=${MINGW_CHOST} \
+    --disable-static \
+    --with-openssldir=${MINGW_PREFIX}/share/libressl \
+    --enable-shared
+  make
+  )
+}
+
+check() {
+  cd "${srcdir}"/build-${MINGW_CHOST}-static
+  make check
+}
+
+package() {
+  cd "${srcdir}"/build-${MINGW_CHOST}-static
+  make DESTDIR="${pkgdir}" install || true
+
+  cd "${srcdir}"/build-${MINGW_CHOST}-shared/crypto
+  make DESTDIR="${pkgdir}" install || true
+
+  cd "${srcdir}"/build-${MINGW_CHOST}-shared/ssl
+  make DESTDIR="${pkgdir}" install || true
+
+  cd "${srcdir}"/build-${MINGW_CHOST}-shared/tls
+  make DESTDIR="${pkgdir}" install || true
+
+  mkdir "${pkgdir}"${MINGW_PREFIX}/include/libressl
+  mv "${pkgdir}"${MINGW_PREFIX}/include/openssl "${pkgdir}"${MINGW_PREFIX}/include/libressl
+}

--- a/patches/libressl-from-Alexpux/libressl-0001-ignore-compiling-test-and-man-module.patch
+++ b/patches/libressl-from-Alexpux/libressl-0001-ignore-compiling-test-and-man-module.patch
@@ -1,0 +1,22 @@
+From 7a902381da24ee426734fe4e6dd9c28b9bc17e4f Mon Sep 17 00:00:00 2001
+From: shinchiro <shinchiro@users.noreply.github.com>
+Date: Mon, 4 Dec 2017 10:39:53 +0800
+Subject: [PATCH] ignore compiling test and man module
+
+---
+ Makefile.am | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Makefile.am b/Makefile.am
+index b4b9dfc..0cbe978 100644
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -1,4 +1,4 @@
+-SUBDIRS = crypto ssl tls include apps tests man
++SUBDIRS = crypto ssl tls include
+ ACLOCAL_AMFLAGS = -I m4
+ 
+ pkgconfigdir = $(libdir)/pkgconfig
+-- 
+2.15.0
+

--- a/patches/opusfile-from-Alexpux/PKGBUILD.txt
+++ b/patches/opusfile-from-Alexpux/PKGBUILD.txt
@@ -1,0 +1,49 @@
+# Maintainer: Francisco Demartino <demartino.francisco@gmail.com>
+
+_realname=opusfile
+pkgbase=mingw-w64-${_realname}
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver=0.11
+pkgrel=2
+pkgdesc="Library for opening, seeking, and decoding .opus files (mingw-w64)"
+arch=('any')
+url="https://www.opus-codec.org/"
+license=("BSD")
+depends=("${MINGW_PACKAGE_PREFIX}-libogg"
+         "${MINGW_PACKAGE_PREFIX}-openssl"
+         "${MINGW_PACKAGE_PREFIX}-opus")
+makedepends=("${MINGW_PACKAGE_PREFIX}-gcc" "${MINGW_PACKAGE_PREFIX}-pkg-config")
+options=('strip' 'staticlibs')
+source=("https://ftp.mozilla.org/pub/mozilla.org/opus/${_realname}-${pkgver}.tar.gz"
+        'no-openssl-wincert.patch')
+sha256sums=('74ce9b6cf4da103133e7b5c95df810ceb7195471e1162ed57af415fabf5603bf'
+            'c87aac7f63e499cffa10a301f902766559cfc121d0c9f92796b2469d7e1c205b')
+
+prepare() {
+  cd "${srcdir}/${_realname}-${pkgver}"
+
+  patch -p1 -i "${srcdir}"/no-openssl-wincert.patch
+}
+
+build() {
+  [[ -d "build-${MINGW_CHOST}" ]] && rm -rf "build-${MINGW_CHOST}"
+  mkdir -p "${srcdir}/build-${MINGW_CHOST}"
+  cd "${srcdir}/build-${MINGW_CHOST}"
+  ../${_realname}-${pkgver}/configure \
+    --prefix=${MINGW_PREFIX} \
+    --build=${MINGW_CHOST} \
+    --host=${MINGW_CHOST} \
+    --target=${MINGW_CHOST} \
+    --enable-shared \
+    --enable-static
+
+  make
+}
+
+package() {
+  cd "${srcdir}/build-${MINGW_CHOST}"
+  make DESTDIR="${pkgdir}" install
+
+  # Install license
+  install -Dm644 ${srcdir}/${_realname}-${pkgver}/COPYING ${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE
+}

--- a/patches/opusfile-from-Alexpux/no-openssl-wincert.patch
+++ b/patches/opusfile-from-Alexpux/no-openssl-wincert.patch
@@ -1,0 +1,33 @@
+diff -Nur opusfile-0.11/src/http.c opusfile-0.11-patched/src/http.c
+--- opusfile-0.11/src/http.c	2018-09-14 23:25:45.000000000 +0200
++++ opusfile-0.11-patched/src/http.c	2018-09-27 15:42:55.161531800 +0200
+@@ -327,10 +327,12 @@
+ typedef ptrdiff_t ssize_t;
+ #  endif
+ 
++#if OPENSSL_VERSION_NUMBER < 0x10100000L
+ /*Load certificates from the built-in certificate store.*/
+ int SSL_CTX_set_default_verify_paths_win32(SSL_CTX *_ssl_ctx);
+ #  define SSL_CTX_set_default_verify_paths \
+  SSL_CTX_set_default_verify_paths_win32
++#endif
+ 
+ # else
+ /*Normal Berkeley sockets.*/
+diff -Nur opusfile-0.11/src/wincerts.c opusfile-0.11-patched/src/wincerts.c
+--- opusfile-0.11/src/wincerts.c	2017-04-22 06:01:35.000000000 +0200
++++ opusfile-0.11-patched/src/wincerts.c	2018-09-27 15:42:23.832739900 +0200
+@@ -33,6 +33,8 @@
+ # include <openssl/err.h>
+ # include <openssl/x509.h>
+ 
++#if OPENSSL_VERSION_NUMBER < 0x10100000L
++
+ static int op_capi_new(X509_LOOKUP *_lu){
+   HCERTSTORE h_store;
+   h_store=CertOpenStore(CERT_STORE_PROV_SYSTEM_A,0,0,
+@@ -171,3 +173,4 @@
+ }
+ 
+ #endif
++#endif

--- a/test_some.sh
+++ b/test_some.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# to get rid of MSDOS format do this to this file: sudo sed -i s/\\r//g ./filename
+# or, open in nano, control-o and then then alt-M a few times to toggle msdos format off and then save
+
+rm ./0.debug.log
+
+./cross_compiler.py -p ffmpeg_static_non_free 2>&1 | tee -a ./0.debug.log
+read -p "done.  press enter to continue"
+./cross_compiler.py -p ffmpeg_static_non_free_opencl 2>&1 | tee -a ./0.debug.log
+read -p "done.  press enter to continue"
+./cross_compiler.py -p x264 2>&1 | tee -a ./0.debug.log
+read -p "done.  press enter to continue"
+./cross_compiler.py -p x265_multibit 2>&1 | tee -a ./0.debug.log
+read -p "done.  press enter to continue"
+./cross_compiler.py -p mp4box 2>&1 | tee -a ./0.debug.log
+read -p "done.  press enter to continue"
+./cross_compiler.py -p lame 2>&1 | tee -a ./0.debug.log
+read -p "done.  press enter to continue"
+./cross_compiler.py -p aom 2>&1 | tee -a ./0.debug.log
+read -p "done.  press enter to continue"
+./cross_compiler.py -p sox 2>&1 | tee -a ./0.debug.log
+read -p "done.  press enter to continue"
+./cross_compiler.py -p vpx 2>&1 | tee -a ./0.debug.log
+read -p "done.  press enter to continue"
+./cross_compiler.py -p mediainfo 2>&1 | tee -a ./0.debug.log
+read -p "done.  press enter to continue"
+./cross_compiler.py -p dav1d 2>&1 | tee -a ./0.debug.log
+read -p "done.  press enter to continue"
+./cross_compiler.py -p fftw3_dll 2>&1 | tee -a ./0.debug.log
+read -p "done.  press enter to continue"


### PR DESCRIPTION
hello.
as briefly outlined in https://github.com/deadsix27/python_cross_compile_script/issues/78#issue-379509890 this pull request has a range of suggestions for you to consider or lose at your pleasure. it doesn't seem to crash building stuff.

> 
> **1. meson/ninja processing added**
> it relies on a range of settings to be false and 'is_meson_ninja' to be true
> use meson/ninja like this below to omit "configure/make" processing and instead perform "meson/ninja" processing
> ```
> 'repo_type' : 'git',
> 'url' : 'https://code.videolan.org/videolan/dav1d.git',
> 'folder_name' : 'libdav1d_git',
> 'needs_configure' : False,
> 'clean_post_configure' : False,
> 'needs_make' : False,
> 'needs_make_install' : False,
> 'is_cmake' : False,
> 'is_meson_ninja' : True,
> 'source_subfolder' : 'build',
> 'create_meson_environment_file' : '{current_path}/meson_environment_ubuntu_mingw64_for_windows_x86_64.txt',
> 'meson_options' : '--prefix={target_prefix} --libdir={target_prefix}/lib --default-library=static --buildtype=plain --backend=ninja --buildtype=release --cross-file={current_path}/meson_environment_ubuntu_mingw64_for_windows_x86_64.txt ./ ../',
> 'run_post_meson' : [
> 	'cat {current_path}/meson_environment_ubuntu_mingw64_for_windows_x86_64.txt',
> ],
> 'ninja_options' : 'install',
> 'run_post_ninja' : [
> 	'chmod +777 {target_prefix}/lib/libdav1d.a',
> 	'chmod +777 {target_prefix}/lib/pkgconfig/dav1d.pc',
> ],
> ```
> 

> **2 fixed nv-codec-headers so ffmpeg nvenc doesn't abort at runtime**

> **3. Added libdav1d into ffmpeg and build dav1d.exe**
> 
> **4. A range of minor suggestions for a range of dependencies, based on your code, jb's code and Alexpux's patches**
> 
> At least threehard coded patch-link needs to be modified to be linked into your tree's repository instead of the fork.
> https://raw.githubusercontent.com/hydra3333/python_cross_compile_script/master/patches/glib2/disable_libmount-make-UTF-yes.patch
> https://raw.githubusercontent.com/hydra3333/python_cross_compile_script/master/patches/opusfile-from-Alexpux/no-openssl-wincert.patch
> https://raw.githubusercontent.com/hydra3333/python_cross_compile_script/master/patches/libressl-from-Alexpux/libressl-0001-ignore-compiling-test-and-man-module.patch
> And anything beginning with 
> https://raw.githubusercontent.com/Alexpux/
> perhaps could(should) be copied into your tree's repository and the hard coded patch-link needs to be modified to be linked into your tree's repository 
> 
> **5. these are the things I try to install to get it to run (the 2 meson/ninja lines ar at the end)**
> 
> ```
> sudo apt-get install -y python python-pip
> sudo apt-get install -y python3 python3-pip
> sudo apt-get install -y cython cython3
> sudo pip  install progressbar2
> sudo pip3 install progressbar2
> sudo pip3 install py2exe
> pip  install progressbar2
> pip3 install progressbar2
> pip3 install py2exe
> sudo apt-get install -y texinfo yasm git make automake gcc gcc-c++ pax cvs svn flex bison patch libtoolize hg cmake gettext-autopoint
> sudo apt-get install -y libxslt rake
> sudo apt-get install -y gperf gyp p7zip docbook-to-man docbook2x pando p7zip
> sudo apt-get install -y build-essential autoconf libtool-bin libtool gettext autopoint gyp gperf autogen bzip2 pandoc 
> sudo apt-get install -y subversion curl texinfo g++ bison flex cvs yasm automake ed gcc cmake git make pkg-config mercurial unzip pax wget ant
> sudo apt-get install -y git-remote-hg libxslt1.1 libxml2 rake docbook-utils docbook-style-xsl docbook-xsl docbook-to-man docbook2x p7zip p7zip-full
> sudo apt-get install -y xsltproc itstool autoconf-archive
> #sudo apt-get remove -y nasm
> sudo apt-get remove -y doxygen
> # gendef is installed with mingw
> sudo apt-get install -y libmozjs-dev libxmu-dev libgconf2-dev libdbus-1-dev network-manager-dev xserver-xorg-dev # for libproxy
> sudo apt-get install -y zlib1g-dev #warning: you may need to install zlib development headers first if you want to build mp4-box on ubuntu
> sudo apt-get install -y p7zip-full
> sudo apt-get install -y autoconf-archive
> sudo apt-get install -y meson
> sudo apt-get install -y python3-distutils
> #
> sudo apt-get install -y docbook2x docbook-xsl
> sudo apt-get install -y dbtoepub docbook-xsl-doc-html docbook-xsl-doc-pdf docbook-xsl-doc-text docbook-xsl-saxon fop libsaxon-java libxalan2-java libxslthl-java xalan
> #
> sudo apt-get install -y python3 python3-pip ninja-build
> pip3 install --user meson
> ```
> 
> **6. if you wanted to use the new nasm 2.14 instead of yasm (something requires nasm anyway IIRC?), this is what I run to build it beforehand and then change yasm to nasm in the script**
> 
> 
> ```
> set -x
> if [[ ! -d "nasm-2.14" ]]; then
>    echo "Downloading nasm 2.14"
>    #url="https://github.com/hydra3333/h3333_python_cross_compile_script/blob/master/miscellaneous/nasm-2.14.tar.xz?raw=true"
>    url="https://www.nasm.us/pub/nasm/releasebuilds/2.14/nasm-2.14.tar.xz"
>    rm -f "nasm-2.14.tar.xz"
>    curl -4 -H 'Pragma: no-cache' -H 'Cache-Control: no-cache' -H 'Cache-Control: max-age=0' "$url" --retry 50 -L --output "nasm-2.14.tar.xz" --fail # -L means "allow redirection" or some odd :|
>    tar -xf "nasm-2.14.tar.xz" || unzip "nasm-2.14.tar.xz"
>    echo "Configuring nasm 2.14"
>    cd nasm-2.14
>       ./autogen.sh || exit 1
>       ./configure --prefix=/usr --exec_prefix=/usr --enable-sections --enable-lto  || exit 1
>       echo "Make nasm 2.14"
>       make  || exit 1
>       echo "Installing nasm 2.14"
>       sudo make install  || exit 1 # sudo so it copies into /usr folder tree
>    cd ..
>    echo "Done Building and Installing nasm 2.14"
> fi
> set +x
> ```
> 